### PR TITLE
feat(lab3): SSH signing + gitleaks pre-commit + history rewrite

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Goal
+<!-- One sentence: what does this PR deliver? -->
+
+## Changes
+<!-- Bullet list of artifacts added or modified -->
+- 
+
+## Testing
+<!-- How you verified it works: commands run + observed output -->
+- 
+
+## Artifacts & Screenshots
+<!-- Links to files in this PR, image embeds where useful -->
+- 
+
+---
+
+### Checklist
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,33 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start Juice Shop
+        run: |
+          docker run -d --name juice-shop -p 3000:3000 bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for Juice Shop to be healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://localhost:3000/rest/admin/application-version > /dev/null; then
+              echo "Juice Shop is up after $((i*2)) seconds"
+              exit 0
+            fi
+            echo "Attempt $i: not ready yet, waiting..."
+            sleep 2
+          done
+          echo "Juice Shop did not become healthy in time"
+          exit 1
+
+      - name: Show homepage response
+        run: |
+          curl -I http://localhost:3000

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -1,0 +1,60 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+- Asset: OWASP Juice Shop (local lab instance)
+- Image: `bkimminich/juice-shop:v20.0.0`
+- Image digest: sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+- Host OS: Windows 11
+- Docker version: Docker version 29.5.2, build 79eb04c
+
+### Deployment Details
+- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+- Access URL: http://127.0.0.1:3000
+- Network exposure: 127.0.0.1 only? [x] Yes [ ] No
+- Container restart policy: default `no` (no --restart flag used)
+
+### Health Check
+- HTTP code on `/`: 200
+- API check (`/api/Products` product count): 46 products returned
+- Container uptime: `juice-shop   Up 54 seconds   127.0.0.1:3000->3000/tcp`
+
+### Initial Surface Snapshot (from browser exploration)
+- Login/Registration visible: [x] Yes — notes: Account menu top-right with Login/Registration
+- Product listing/search present: [x] Yes — notes: products and search icon visible on landing page
+- Admin or account area discoverable: [x] Yes — notes: Account menu present
+- Client-side errors in DevTools console: [ ] Yes [x] No — notes: only an informational "Slow network / fallback font" warning, no critical errors
+- Pre-populated local storage / cookies: Local Storage empty on first load; a "fruit cookies" consent banner is shown
+
+### Security Headers (Quick Look)
+Run: `curl.exe -I http://127.0.0.1:3000`. Output (relevant headers):
+```
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+Feature-Policy: payment 'self'
+Content-Type: text/html; charset=UTF-8
+```
+Which of these are MISSING?
+- [x] `Content-Security-Policy`
+- [x] `Strict-Transport-Security`
+- [ ] `X-Content-Type-Options: nosniff` (present)
+- [ ] `X-Frame-Options` (present, SAMEORIGIN)
+
+### Top 3 Risks Observed
+1. **Missing Content-Security-Policy header** — Without a CSP, the browser has no restriction on which scripts it may execute, which makes cross-site scripting (XSS) attacks significantly easier to pull off and harder to contain. Maps to OWASP Top 10:2025 A06 (Security Misconfiguration).
+2. **Missing Strict-Transport-Security header** — The app does not instruct browsers to enforce HTTPS, leaving users exposed to downgrade and man-in-the-middle attacks on untrusted networks. Maps to OWASP Top 10:2025 A06 (Security Misconfiguration).
+3. **Overly permissive CORS (`Access-Control-Allow-Origin: *`)** — The API accepts cross-origin requests from any website, so a malicious site could interact with the API on behalf of a victim. Maps to OWASP Top 10:2025 A05 (Broken Access Control).
+
+## PR Template Setup
+
+- File: `.github/PULL_REQUEST_TEMPLATE.md`
+- Sections included: Goal / Changes / Testing / Artifacts & Screenshots
+- Checklist items: clear title; no secrets/large files; submission file exists
+- Auto-fill verified: [ ] Yes — to confirm when opening the PR
+
+## GitHub Community
+
+Starring repositories bookmarks useful projects for later, signals trust and popularity to other developers, and helps maintainers gain visibility for their work. Following developers keeps me updated on what teammates and the wider community are building, helps me discover new projects through their activity, and builds professional connections useful for future collaboration.

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -58,3 +58,12 @@ Which of these are MISSING?
 ## GitHub Community
 
 Starring repositories bookmarks useful projects for later, signals trust and popularity to other developers, and helps maintainers gain visibility for their work. Following developers keeps me updated on what teammates and the wider community are building, helps me discover new projects through their activity, and builds professional connections useful for future collaboration.
+
+## Bonus: CI Smoke Test
+
+- Workflow file: `.github/workflows/lab1-smoke.yml`
+- Trigger: `pull_request` on main
+- Permissions: `contents: read` (workflow level)
+- Run URL (green): https://github.com/Basinkse21/DevSecOps-Intro/actions/runs/27057942363
+- Workflow run duration: ~17s
+- Smoke test result: smoke-test succeeded, Juice Shop returned healthy

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -53,7 +53,7 @@ Which of these are MISSING?
 - File: `.github/PULL_REQUEST_TEMPLATE.md`
 - Sections included: Goal / Changes / Testing / Artifacts & Screenshots
 - Checklist items: clear title; no secrets/large files; submission file exists
-- Auto-fill verified: [ ] Yes — to confirm when opening the PR
+- Auto-fill verified: [x] Yes — opening a PR from a feature branch into `main` of my fork auto-populated the description with the full template (Goal / Changes / Testing / Artifacts + 3-item checklist), confirmed before any manual edits. Screenshot attached.
 
 ## GitHub Community
 

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,0 +1,1 @@
+﻿# Lab 3 — Submission

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,1 +1,90 @@
 ﻿# Lab 3 — Submission
+
+## Task 1: SSH Commit Signing
+
+### Local configuration
+- `git config --global gpg.format` -> ssh
+- `git config --global user.signingkey` -> C:\Users\kamh1\.ssh\id_ed25519.pub
+- `git config --global commit.gpgsign` -> true
+
+### Local verification
+Output of `git log --show-signature -1`:
+
+    Good "git" signature for kam.h116@mail.ru with ED25519 key SHA256:ugfsT50oXshPRR780RTl+hPWtsoXSebjxm/ZkGRqIYo
+    Author: Basinkse21 <kam.h116@mail.ru>
+    test: first signed commit
+
+### GitHub verification
+- Direct link to the commit: https://github.com/Basinkse21/DevSecOps-Intro/commit/e6b68f1
+- Screenshot of the Verified badge: attached in the PR.
+
+### Reflection (STRIDE-R)
+Without commit signing, anyone can set `user.name` and `user.email` to a colleague's identity and push commits that appear to be authored by them — a Repudiation (STRIDE-R) problem, since the real author can deny their work and a malicious one can frame someone else (e.g. slipping a backdoor in under a senior engineer's name). The Verified badge makes this visible because it only appears when the commit carries a cryptographic signature tied to a key the claimed author registered with GitHub; an impersonated commit simply shows no Verified badge, so reviewers can spot it.
+
+## Task 2: Pre-commit + gitleaks
+
+### .pre-commit-config.yaml
+    repos:
+      - repo: https://github.com/gitleaks/gitleaks
+        rev: v8.21.2
+        hooks:
+          - id: gitleaks
+      - repo: https://github.com/pre-commit/pre-commit-hooks
+        rev: v5.0.0
+        hooks:
+          - id: detect-private-key
+          - id: check-added-large-files
+
+### pre-commit install output
+    pre-commit installed at .git\hooks\pre-commit
+
+### The blocked commit
+The commit `test: should be blocked by gitleaks` was aborted by the gitleaks hook:
+
+    Detect hardcoded secrets.................................................Failed
+    - hook id: gitleaks
+    - exit code: 1
+    Finding:     GH_PAT=REDACTED
+    Secret:      REDACTED
+    RuleID:      github-pat
+    File:        submissions/leak-attempt.txt
+    Line:        1
+    leaks found: 1
+
+(Note: a first `pre-commit run --all-files` also flagged a planted private key in
+`labs/lab6/vulnerable-iac/ansible/configure.yml` via the `detect-private-key` hook —
+course plumbing for a later lab, which confirms that hook works too.)
+
+### Tune-out exercise
+1. **Inline allowlist** (`[allowlist]` block in `.gitleaks.toml`): This is acceptable when the flagged string is genuinely a non-secret — e.g. a well-known documentation example or a test fixture — and you allowlist that *specific* value (or a tight regex). It keeps the scan strict everywhere else while silencing one known false positive. It is OK precisely because it is narrow and reviewable.
+2. **Path exclusion** (`paths: [docs/]` in `.gitleaks.toml`): This is risky because it turns off scanning for an *entire directory*. A real secret committed under `docs/` later would sail through undetected. Excluding a path trades safety for convenience over a broad area, so it should be a last resort and kept as small as possible.
+
+## Bonus: History Rewrite
+
+### Before
+    21ac8e6 docs: add usage notes
+    bf9b4ff feat: empty log
+    1f5f5cf feat: add config
+    8fb4464 init
+
+`git log -p | Select-String "ghp_AAAA"` count: **2**
+
+### After
+    d5d6038 docs: add usage notes
+    a4fcaf6 feat: empty log
+    245b8e3 feat: add config
+    e4b0bce init
+
+`git log -p | Select-String "ghp_AAAA"` count: **0**
+`git log -p | Select-String "REDACTED"` count: **2**
+
+(Note: every commit hash changed after the rewrite — filter-repo recreated the
+entire history, so the commits that contained the secret no longer exist.)
+
+### The two-step pattern in real life
+1. `git filter-repo --replace-text replacements.txt` — rewrite history locally and force-push to purge the secret from the remote.
+2. **Rotate the secret.** Rewriting history only removes the secret from the repo's record — but by then it has already been exposed (cloned, cached, possibly read). The mandatory second step is to revoke the leaked credential and issue a new one. Cleanup hides the secret; rotation is what actually removes the risk.
+
+### Two real-world gotchas
+1. `git filter-repo` refused to run with "this does not look like a fresh clone" and aborted. It is destructive by design and won't touch a repo it isn't sure about; I had to re-run with `--force` (safe here because it's a throwaway sandbox, but a real incident should run on a fresh clone).
+2. On Windows there is no `grep`, so the lab's `git log -p | grep -c` had to be replaced with `git log -p | Select-String ... | Measure-Object -Line`. The verification idea is the same, but the exact command from the lab (written for Linux) does not run as-is in PowerShell.


### PR DESCRIPTION
## Goal
Configure SSH commit signing, wire gitleaks into a pre-commit hook, and practice history rewriting with git filter-repo.

## Changes
- `.pre-commit-config.yaml` — gitleaks + detect-private-key + check-added-large-files hooks
- `submissions/lab3.md` — signing config + verification, blocked-commit evidence, history-rewrite analysis

## Testing
- All commits on this branch show Verified on GitHub (SSH signing key registered)
- `git log --show-signature -1` → Good "git" signature
- gitleaks blocked a planted GitHub PAT (RuleID: github-pat) at commit time
- filter-repo sandbox: secret count in history went 2 → 0, REDACTED marker → 2

## Artifacts & Screenshots
- Analysis: `submissions/lab3.md`
- Verified badge screenshot: attached below

---

### Checklist
- [x] Task 1 — SSH signing configured + Verified badge on commit
- [x] Task 2 — .pre-commit-config.yaml + gitleaks demonstrably blocking
- [x] Bonus — filter-repo rewrite practice documented