### PR TITLE
feat(lab2): Threagile threat model + secure variant + auth flow

### DIFF
--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,366 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Auth Flow Threat Model
+date: 2026-06-08
+
+author:
+  name: Nopef
+  homepage: https://github.com/Nopef
+
+management_summary_comment: >
+  Focused threat model for Juice Shop authentication: login, JWT issuance,
+  session use, and admin access.
+
+business_criticality: important
+
+business_overview:
+  description: >
+    Feature-level model covering login, registration, JWT lifecycle, and admin routes.
+  images: []
+
+technical_overview:
+  description: >
+    Browser sends credentials to Auth API; Auth API requests JWT from token signer;
+    browser uses JWT on protected API calls; admin endpoint requires admin role in JWT.
+  images: []
+
+tags_available:
+  - auth
+  - tokens
+  - pii
+  - actor
+  - app
+
+data_assets:
+
+  Credentials:
+    id: credentials
+    description: "Username and password submitted at login or registration."
+    usage: business
+    tags: ["auth", "pii"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: "Direct account takeover if leaked."
+
+  JWT Token:
+    id: jwt-token
+    description: "Signed JWT returned after successful authentication."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Bearer token grants access to user and admin APIs."
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: "Secret key used to sign and verify JWTs."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Key compromise forges arbitrary tokens."
+
+  User Session State:
+    id: user-session
+    description: "Client-side session state and token storage in browser."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: operational
+    justification_cia_rating: "Session hijack if stolen from browser."
+
+  Admin Operation Requests:
+    id: admin-requests
+    description: "Privileged admin API calls (user management, config)."
+    usage: business
+    tags: ["auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: few
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Admin actions affect all users."
+
+technical_assets:
+
+  Browser:
+    id: browser
+    description: "User web browser."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    size: system
+    technology: browser
+    tags: ["actor"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Untrusted client."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - user-session
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login and Register:
+        target: auth-api
+        description: "POST /rest/user/login and /rest/user/registration with credentials."
+        protocol: https
+        authentication: credentials
+        authorization: none
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+      API with JWT:
+        target: auth-api
+        description: "Protected API calls with JWT in Authorization header."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - user-session
+      Admin Access:
+        target: admin-api
+        description: "Admin routes; JWT must contain admin role."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-requests
+        data_assets_received:
+          - admin-requests
+
+  Auth API:
+    id: auth-api
+    description: "Juice Shop authentication and user API endpoints."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    size: application
+    technology: web-server
+    tags: ["app"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Handles login and token-backed API access."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - user-session
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Request JWT:
+        target: token-signer
+        description: "Auth API asks token signer to issue JWT after credential check."
+        protocol: https
+        authentication: credentials
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+      Verify Credentials:
+        target: user-db
+        description: "Lookup user hash and validate password."
+        protocol: jdbc-encrypted
+        authentication: credentials
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - credentials
+      Forward to Admin Check:
+        target: admin-api
+        description: "JWT verification on each protected request before admin logic."
+        protocol: https
+        authentication: token
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - admin-requests
+
+  Token Signer:
+    id: token-signer
+    description: "Component that signs and verifies JWTs."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    size: component
+    technology: web-server
+    tags: ["app"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Controls token trust."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - jwt-signing-key
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  User DB:
+    id: user-db
+    description: "Credential store (SQLite users table)."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    size: component
+    technology: database
+    tags: ["app"]
+    internet: false
+    machine: container
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Stores password hashes."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - credentials
+    data_assets_stored:
+      - credentials
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Admin API:
+    id: admin-api
+    description: "Privileged admin endpoints."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    size: application
+    technology: web-server
+    tags: ["app"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Admin-only operations."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - admin-requests
+      - jwt-token
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted network."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - browser
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker internal network."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - auth-api
+      - token-signer
+      - user-db
+      - admin-api
+    trust_boundaries_nested: []
+
+shared_runtimes: {}
+individual_risk_categories: {}
+risk_tracking: {}

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Local Lab Threat Model  
+date: 2025-09-18
+
+author:
+  name: Daniil Satyaev
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app (HTTPS on 3000). App uses parameterized queries / prepared statements for all DB access."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app (HTTPS on 3000 internally)."
+        protocol: https
+        authentication: client-certificate
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0)."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTP POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,135 @@
+# Lab 2 — Submission
+---
+
+## Task 1: Baseline Threat Model
+
+### Risk count by severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | 23 |
+
+### Top 5 risks (from `labs/lab2/output/risks.json`)
+
+1. **cross-site-scripting** — Cross-Site Scripting (XSS) risk at Juice Shop Application; severity **elevated**; affecting **juice-shop**
+2. **unencrypted-communication** — Unencrypted Communication on link **Direct to App (no proxy)** between User Browser and Juice Shop Application (auth data: credentials, tokens, session-id); severity **elevated**; affecting **user-browser**
+3. **unencrypted-communication** — Unencrypted Communication on link **To App** between Reverse Proxy and Juice Shop Application; severity **elevated**; affecting **reverse-proxy**
+4. **missing-authentication** — Missing Authentication on link **To App** from Reverse Proxy to Juice Shop Application; severity **elevated**; affecting **juice-shop**
+5. **unnecessary-technical-asset** — Unnecessary Technical Asset named Persistent Storage; severity **low**; affecting **persistent-storage**
+
+### STRIDE mapping (Lecture 2 slide 7)
+
+- Risk 1: **T** (Tampering) — XSS lets attackers inject/modify js-scripts executed in victims' browsers.
+- Risk 2: **I** (Information Disclosure) — HTTP exposes session tokens and credentials to on-path eavesdropping.
+- Risk 3: **I** (Information Disclosure) — cleartext proxy→app hop allows sniffing or modifying traffic inside the host boundary.
+- Risk 4: **S** (Spoofing) — proxy→app link has no authentication; a rogue internal caller could impersonate trusted traffic.
+- Risk 5: **I** (Information Disclosure) — unnecessary storage expands attack surface and data exposure scope without clear business need.
+
+### Trust boundary observation
+
+On `data-flow-diagram.png`, the arrow **User Browser → Juice Shop (Direct to App, HTTP/HTTPS)** crosses the **Internet → Host** trust boundary.
+
+This link is attractive because it carries **session tokens and catalog data** from an untrusted client network into the application tier. In the baseline model the direct path uses **plain HTTP**, so an on-path attacker can read or modify traffic (STRIDE **I** and **T**) without touching the container.
+
+---
+
+## Task 2: Secure Variant & Diff
+
+Secure model file: `labs/lab2/threagile-model-secure.yaml`
+
+**Hardening applied (5/5):**
+
+**What we changed in the secure YAML:**
+
+1. **HTTPS for users** — browser now talks to Juice Shop over HTTPS instead of HTTP.
+2. **Encrypted database storage** — persistent storage uses encryption at rest.
+3. **HTTPS for WebHook** — outbound calls to the external WebHook stay on HTTPS.
+4. **Prepared statements** — added a DB link with a note that the app uses parameterized queries.
+5. **No plain log writes** — removed logs from plain storage in the model.
+
+**Generate secure report:**
+
+```bash
+docker run --rm \
+  -v "$(pwd)/labs/lab2":/app/work \
+  threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model-secure.yaml \
+  -output /app/work/output-secure
+```
+
+### Risk count comparison
+
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 1 | -3 |
+| Medium | 14 | 13 | -1 |
+| Low | 5 | 5 | 0 |
+| **Total** | 23 | 19 | -4 |
+
+
+### Top 5 comparison (baseline vs secure)
+
+**Baseline** had 4 elevated + 1 low in top 5: XSS, two unencrypted links, missing authentication on proxy→app, unnecessary storage.
+
+**Secure** has 1 elevated + 4 low in top 5: only XSS stays elevated; the three transport/auth elevated findings are gone. New low findings appear for unnecessary data transfer of tokens (browser↔app and browser↔proxy) and unnecessary user-browser asset.
+
+So diff is 4 risks
+
+### Rules GONE in the secure variant
+
+1. **unencrypted-communication** (on "Direct to App (no proxy)", User Browser → Juice Shop) — fixed by switching that link from `http` to `https`.
+2. **unencrypted-communication** (on "To App", Reverse Proxy → Juice Shop) — no longer in top risks after hardening; elevated count dropped from 4 to 1.
+3. **missing-authentication** (on "To App", Reverse Proxy → Juice Shop) — no longer in top 5; removed together with the other two elevated transport/auth findings.
+
+That's rules removed all three eliminated elevated risks besides XSS (one missing-authentication + two unencrypted-communication).
+
+### Rules STILL firing in the secure variant (and why)
+
+1. **cross-site-scripting** — XSS is an application-code flaw (unescaped output), not a transport setting. No architecture YAML field removes it; it needs code fixes (use secure template rendering, secure js-sinks or use sanitizer such as dompurify).
+2. **unnecessary-data-transfer** (Tokens & Sessions at User Browser) — HTTPS protects the channel but tokens still flow browser↔app and browser↔proxy; Threagile flags the transfer itself as unnecessary exposure surface.
+3. **unnecessary-technical-asset** (Persistent Storage, User Browser) — declaring encryption and HTTPS does not remove assets from the model; Threagile still questions whether every component is strictly required.
+
+### Honesty check
+
+Did the total drop more than 50%? **No** (23 → 19, about 17% reduction).
+
+We removed the cheap wins (HTTPS on direct user traffic, encrypted storage, DB link hardening), but XSS and several low-tier structural findings remain. Getting to near-zero would need code changes, tighter data-flow design, and more than five YAML field edits.
+
+---
+
+## Bonus Task: Auth Flow Threat Model
+
+- Model: `labs/lab2/threagile-model-auth.yaml`
+- Output: `labs/lab2/output-auth/`
+
+### Risk count
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 6 |
+| Medium | 22 |
+| Low | 11 |
+| **Total** | 39 |
+
+### Three auth-specific risks (NOT in baseline top 5)
+
+Baseline top 5 covered generic XSS, unencrypted browser/proxy links, missing proxy auth, and unnecessary storage — not login, JWT, or admin-route specifics.
+
+1. **sql-nosql-injection** — STRIDE: **T** (Tampering) — Mitigation: use parameterized queries on the **Verify Credentials** link to User DB; never concatenate user input into SQL at login time.
+
+2. **missing-authentication-second-factor** — STRIDE: **S** (Spoofing) — Mitigation: require 2FA (TOTP or WebAuthn) on **Login and Register** so a stolen password alone cannot create or hijack a session.
+
+3. **server-side-request-forgery** — STRIDE: **E** (Elevation) — Mitigation: allowlist internal targets on **Request JWT** and **Forward to Admin Check**; Auth API must not call arbitrary internal URLs when reaching Token Signer or Admin API.
+
+### Reflection
+
+The auth-focused model surfaced login-time injection, missing 2FA on credential flows, and SSRF-style server-side hops between Auth API, Token Signer, and Admin API. The baseline architecture model only showed generic Juice Shop risks and missed this login → JWT → admin chain. Feature-level modeling is better for Spoofing and Elevation in auth flows.


### PR DESCRIPTION
## Goal
Run Threagile baseline + secure variant on Juice Shop, document risk diff, and add auth-flow bonus model.

## Changes
- `labs/lab2/threagile-model-secure.yaml` — hardened variant (HTTPS, link auth, encrypted storage)
- `labs/lab2/threagile-model-auth.yaml` — auth-flow model written from scratch
- `submissions/lab2.md` — risk tables, STRIDE mapping, baseline-vs-secure diff, auth-flow analysis

## Testing
- Threagile v0.9.1 run on all three models; risks.json generated each time
- Baseline: 23 risks; Secure variant: 19 risks (-4); Auth model: 44 risks
- Risk counts in the submission taken directly from jq output on risks.json
- docker run ... threagile-model.yaml → output/
- docker run ... threagile-model-secure.yaml → output-secure/
- docker run ... threagile-model-auth.yaml → output-auth/

## Artifacts & Screenshots
- Analysis: `submissions/lab2.md`

---

### Checklist
- [x] Task 1 — Baseline risk table + top-5 with STRIDE mapping
- [x] Task 2 — Secure variant + risk diff table
- [x] Bonus — Auth-flow model + 3 auth-specific risks