### PR TITLE
feat(lab2): Threagile threat model + secure variant + auth flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Goal
+
+<!-- 1 sentence: what this PR delivers -->
+
+## Changes
+
+<!-- Bullet list of artifacts added or modified -->
+- 
+
+## Testing
+
+<!-- Commands you ran and the observed output that proves it works -->
+
+## Artifacts & Screenshots
+
+<!-- Links to files in this PR; embed screenshots with ![alt](url) where useful -->
+
+---
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,461 @@
+threagile_version: 1.0.0
+
+title: Juice Shop Auth Flow — Focused Threat Model
+date: 2026-06-08
+
+author:
+  name: Georgii Beliaev
+  homepage: https://github.com/JoraXD
+
+management_summary_comment: >
+  Focused threat model of the OWASP Juice Shop authentication flow.
+  Covers login, JWT issuance, session usage, and admin endpoint access.
+  Trust boundaries: Internet (browser) → Container (auth API, token signer,
+  credential store, admin endpoint). STRIDE focus: Spoofing and Elevation of Privilege.
+
+business_criticality: important
+
+business_overview:
+  description: >
+    Authentication sub-system of OWASP Juice Shop. Users log in with
+    email/password, receive a JWT signed by a shared secret, and present
+    that token on every subsequent request. Admin routes additionally
+    require the token to carry an admin role claim.
+  images: []
+
+technical_overview:
+  description: >
+    Browser sends credentials over HTTP to the Auth API. The Auth API
+    validates credentials against the SQLite credential store and asks
+    the Token Signer to produce a JWT. The JWT is returned to the browser
+    and carried in the Authorization header on all subsequent calls,
+    including calls to the Admin Endpoint. The Token Signer holds the
+    HS256 signing key in memory (no vault).
+  images: []
+
+questions:
+  Is the JWT signing key stored in a secrets manager?: ""
+  Is MFA enforced for admin accounts?: ""
+  Are login attempts rate-limited or audited?: ""
+  Does the admin endpoint re-verify the role claim server-side?: ""
+
+abuse_cases:
+  JWT Secret Brute-Force: >
+    The HS256 signing key is short and stored in plaintext in the source
+    repository. An attacker who obtains the key can forge admin-role tokens.
+  Credential Stuffing on Login: >
+    No rate limiting on /rest/user/login allows automated attempts with
+    leaked password lists to compromise user accounts.
+  Broken Object Level Authorization on Admin Routes: >
+    Admin endpoints trust the role claim in the JWT without additional
+    server-side ACL checks, so a forged token grants full admin access.
+
+security_requirements:
+  Strong JWT secret: Use a cryptographically random secret of at least 256 bits stored in a secrets manager, never in source code.
+  MFA for admins: Require a second factor for any account with an admin role claim.
+  Rate limiting: Enforce per-IP and per-account rate limits on the login endpoint.
+  Server-side role checks: Re-validate the role claim against the database on every admin request, not just via JWT parsing.
+
+tags_available:
+  - browser
+  - auth
+  - jwt
+  - admin
+  - credentials
+  - signing-key
+  - datastore
+  - api
+  - internet
+  - container
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  Credentials:
+    id: credentials
+    description: "User email and password submitted during login or registration."
+    usage: business
+    tags: ["auth", "credentials"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: >
+      Plaintext passwords must never be stored or logged. Integrity is critical
+      to prevent account takeover via credential tampering.
+
+  JWT Token:
+    id: jwt-token
+    description: "HS256-signed JSON Web Token issued after successful login, carrying user id and role claim."
+    usage: business
+    tags: ["auth", "jwt"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: >
+      A stolen or forged JWT allows full session hijacking or privilege escalation.
+      Integrity (signature validity) is critical.
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: "HS256 shared secret used to sign and verify all JWTs. Stored in application memory and source code."
+    usage: devops
+    tags: ["auth", "signing-key"]
+    origin: application
+    owner: Lab Owner
+    quantity: very-few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Compromise of the signing key allows an attacker to forge arbitrary JWTs,
+      including admin-role tokens. Must be treated as the most sensitive secret.
+
+  User Session State:
+    id: session-state
+    description: "Active session context: authenticated user id, role, basket id."
+    usage: business
+    tags: ["auth", "jwt"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: operational
+    justification_cia_rating: >
+      Session state determines what a user can do. Tampering enables privilege
+      escalation; disclosure enables session hijacking.
+
+  Admin Operation Requests:
+    id: admin-requests
+    description: "Requests to admin-only endpoints (user list, challenge management, feedback deletion)."
+    usage: business
+    tags: ["admin"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: few
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Admin operations mutate user data and application state. Unauthorized
+      admin access has the highest business impact.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  Browser:
+    id: browser
+    description: "End-user web browser performing login and accessing protected routes."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["browser", "internet"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user — potentially an attacker."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - jwt-token
+      - session-state
+    data_assets_stored:
+      - jwt-token
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login Request:
+        target: auth-api
+        description: "Browser sends email+password to /rest/user/login over HTTP (no TLS in default setup)."
+        protocol: http
+        authentication: credentials
+        authorization: none
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+      Authenticated API Call:
+        target: auth-api
+        description: "Browser sends JWT in Authorization header to access protected API routes."
+        protocol: http
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - session-state
+        data_assets_received:
+          - session-state
+      Admin Endpoint Access:
+        target: admin-endpoint
+        description: "Browser sends JWT with admin role claim to /api/Users or /rest/admin/* routes."
+        protocol: http
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["admin"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-requests
+        data_assets_received:
+          - admin-requests
+
+  Auth API:
+    id: auth-api
+    description: "Juice Shop Express routes handling /rest/user/login, /rest/user/register, and JWT validation middleware."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-service-rest
+    tags: ["api", "auth", "container"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      The auth API is the trust anchor for the entire session model. Compromise
+      allows issuing or accepting arbitrary tokens.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - jwt-signing-key
+      - session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Request JWT Signing:
+        target: token-signer
+        description: "Auth API asks Token Signer to produce a JWT after credential validation."
+        protocol: http
+        authentication: none
+        authorization: none
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - session-state
+        data_assets_received:
+          - jwt-token
+      Credential Lookup:
+        target: credential-store
+        description: "Auth API queries SQLite for the user record matching the submitted email."
+        protocol: jdbc
+        authentication: none
+        authorization: none
+        tags: ["auth", "datastore"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - credentials
+
+  Token Signer:
+    id: token-signer
+    description: "Component that loads the HS256 signing key from an environment variable (or hardcoded default) and signs/verifies JWTs."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: library
+    tags: ["auth", "signing-key", "container"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Holds the signing key in memory. If the process is compromised or the
+      key is leaked, all issued tokens can be forged.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-signing-key
+      - jwt-token
+      - session-state
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Credential Store:
+    id: credential-store
+    description: "SQLite database storing user records: email, bcrypt-hashed password, role."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: database
+    tags: ["datastore", "auth", "container"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains hashed credentials and role assignments. Integrity is critical
+      — tampering can escalate any user to admin.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - credentials
+      - session-state
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Admin Endpoint:
+    id: admin-endpoint
+    description: "Juice Shop admin routes (/api/Users, /rest/admin/application-configuration, /rest/admin/application-version) protected only by JWT role claim check."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-service-rest
+    tags: ["admin", "api", "container"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Admin endpoints expose all user data and application configuration.
+      A single authorization bypass here has maximum blast radius.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - admin-requests
+      - session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Admin DB Access:
+        target: credential-store
+        description: "Admin endpoint reads/writes user records for management operations."
+        protocol: jdbc
+        authentication: none
+        authorization: none
+        tags: ["admin", "datastore"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - admin-requests
+        data_assets_received:
+          - credentials
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network. Browser is here."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - browser
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network running all Juice Shop processes."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - auth-api
+      - token-signer
+      - credential-store
+      - admin-endpoint
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Juice Shop Container:
+    id: juice-shop-container
+    description: "Single Docker container running all auth-related processes."
+    tags: ["container"]
+    technical_assets_running:
+      - auth-api
+      - token-signer
+      - admin-endpoint
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Secure Variant Threat Model
+date: 2026-06-08
+
+author:
+  name: Georgii Beliaev
+  homepage: https://github.com/JoraXD
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app (HTTPS on 3000 — TLS enforced in secure variant)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app (HTTPS internally — mTLS between proxy and app in secure variant)."
+        protocol: https
+        authentication: token
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0). Secure variant: all DB queries use parameterized statements (prepared statements) to eliminate SQL injection. JWT signing key stored in environment variable, not hardcoded."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTP POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs. Secure variant: volume encrypted at rest with AES-256 symmetric key."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,122 @@
+# Lab 2 — Submission
+
+## Task 1: Baseline Threat Model
+
+### Risk count by severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | **23** |
+
+Generated with:
+```bash
+docker run --rm \
+  -v "$(pwd)/labs/lab2":/app/work \
+  threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model.yaml \
+  -output /app/work/output
+jq '[.[] | .severity] | group_by(.) | map({severity: .[0], count: length})' \
+  labs/lab2/output/risks.json
+```
+
+### Top 5 risks
+
+1. **cross-site-scripting** — Cross-Site Scripting (XSS) risk at Juice Shop Application; severity **elevated**; affecting `juice-shop`
+2. **unencrypted-communication** — Unencrypted Communication on link *Direct to App (no proxy)* between User Browser and Juice Shop Application, transferring authentication data; severity **elevated**; affecting `user-browser`
+3. **unencrypted-communication** — Unencrypted Communication on link *To App* between Reverse Proxy and Juice Shop Application; severity **elevated**; affecting `reverse-proxy`
+4. **missing-authentication** — Missing Authentication covering communication link *To App* from Reverse Proxy to Juice Shop Application; severity **elevated**; affecting `juice-shop`
+5. **missing-build-infrastructure** — Missing Build Infrastructure in the threat model; severity **medium**; affecting `juice-shop`
+
+### STRIDE mapping (Lecture 2 slide 7)
+
+- Risk 1 (`cross-site-scripting`): **T + S** — XSS lets an attacker inject scripts that tamper with page content (Tampering) and act as the victim user, effectively spoofing their identity to the server (Spoofing).
+- Risk 2 (`unencrypted-communication`, user→app): **I** — Credentials and session tokens sent over plaintext HTTP can be captured by any network observer, directly disclosing confidential data (Information Disclosure).
+- Risk 3 (`unencrypted-communication`, proxy→app): **I** — Even after TLS terminates at the proxy, the internal hop to the app is unencrypted; a process on the same host can intercept tokens in transit (Information Disclosure).
+- Risk 4 (`missing-authentication`, proxy→app): **S** — Any process that can reach the app's internal port can impersonate a legitimate downstream request with no credential challenge (Spoofing).
+- Risk 5 (`missing-build-infrastructure`): **T** — Without a declared, verifiable build pipeline, supply-chain tampering (malicious dependency or image layer substitution) is undetectable (Tampering).
+
+### Trust boundary observation
+
+In `data-flow-diagram.png` the arrow **User Browser → Juice Shop Application** (*Direct to App, no proxy*) crosses from the **Internet** trust boundary directly into the **Container Network**, bypassing the reverse proxy entirely. This link is especially attractive to an attacker because it carries `tokens-sessions` data assets over plain HTTP — meaning any network observer between the client and the host machine captures live session tokens with zero effort, and the app cannot distinguish a legitimate browser from a replayed stolen session.
+
+---
+
+## Task 2: Secure Variant & Diff
+
+### Changes made to `threagile-model-secure.yaml`
+
+| Change | Location | Before → After |
+|--------|----------|----------------|
+| Force HTTPS on direct user link | `User Browser → Direct to App` communication link | `protocol: http` → `protocol: https` |
+| TLS + auth on internal proxy link | `Reverse Proxy → To App` communication link | `protocol: http, authentication: none` → `protocol: https, authentication: token` |
+| Encrypt storage at rest | `Persistent Storage` technical asset | `encryption: none` → `encryption: data-with-symmetric-shared-key` |
+| Declare parameterized queries | `Juice Shop Application` description | Added note that all DB queries use prepared statements |
+| Strengthen internal auth | `Reverse Proxy → To App` | `authorization: none` → `authorization: technical-user` |
+
+### Risk count comparison
+
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 1 | **−3** |
+| Medium | 14 | 13 | **−1** |
+| Low | 5 | 5 | 0 |
+| **Total** | **23** | **19** | **−4** |
+
+### Which rules are GONE in the secure variant?
+
+1. `unencrypted-communication` (link *Direct to App (no proxy)*, User Browser → Juice Shop Application) — fixed by changing `protocol: http` → `protocol: https` on the direct browser-to-app link.
+2. `unencrypted-communication` (link *To App*, Reverse Proxy → Juice Shop Application) — fixed by changing `protocol: http` → `protocol: https` on the internal proxy-to-app link.
+3. `missing-authentication` (link *To App*, Reverse Proxy → Juice Shop Application) — fixed by adding `authentication: token` and `authorization: technical-user` on the same proxy→app link.
+
+### Which rules are STILL THERE in the secure variant?
+
+1. **`cross-site-scripting`** (elevated) — XSS is a code-level vulnerability in how the application renders untrusted user input. Changing transport protocol and encryption at rest does nothing to prevent a stored XSS payload from executing in another user's browser. Eliminating this requires output encoding and a Content-Security-Policy enforced at the application layer.
+
+2. **`unencrypted-asset`** (medium) — The `Juice Shop Application` asset itself still has `encryption: none` at the process level. Threagile flags this separately from storage encryption: even though the volume is now encrypted, the running process holds plaintext data in memory and does not declare application-level encryption of data assets it processes (user accounts, tokens). Fixing this would require declaring `encryption: data-with-symmetric-shared-key` on the technical asset itself, not just the storage.
+
+### Honesty check
+
+The total dropped from 23 to 19 — a **17% reduction**, well under 50%. This makes sense: transport and storage hardening are infrastructure-level changes that address a handful of rules in Threagile's ruleset. The majority of remaining risks (`cross-site-scripting`, `cross-site-request-forgery`, `missing-vault`, `missing-identity-store`, `server-side-request-forgery`, `container-baseimage-backdooring`, etc.) are architectural and code-level issues that require application changes, a secrets management system, WAF deployment, and a verified build pipeline. The five one-field changes we made are cheap wins with high signal-to-noise on the most severe (elevated) findings, but they account for only a small fraction of total remediation effort.
+
+---
+
+## Bonus Task: Auth Flow Threat Model
+
+### Risk count
+
+| Severity | Count |
+|----------|------:|
+| High | 2 |
+| Elevated | 11 |
+| Medium | 22 |
+| Low | 5 |
+| **Total** | **40** |
+
+Generated with:
+```bash
+docker run --rm \
+  -v "$(pwd)/labs/lab2":/app/work \
+  threagile/threagile:0.9.1 \
+  -model /app/work/threagile-model-auth.yaml \
+  -output /app/work/output-auth \
+  -generate-risks-excel=false -generate-tags-excel=false
+```
+
+### Three auth-specific risks (NOT in the baseline model's top 5)
+
+1. **`sql-nosql-injection`** — STRIDE: **T (Tampering)** — The Admin Endpoint issues unparameterized SQL queries against the Credential Store. An attacker with a forged admin JWT can craft malicious input in admin API calls to modify or exfiltrate any user record. Mitigation: enforce parameterized queries (prepared statements) for all database access in the admin routes.
+
+2. **`server-side-request-forgery`** — STRIDE: **S (Spoofing)** — The Auth API makes an internal HTTP call to the Token Signer with no authentication on that link. An attacker who controls the Auth API process (or can inject into its request path) can redirect that call to an arbitrary internal target, making the Token Signer component appear to be a trusted internal service when it is not. Mitigation: restrict the Token Signer to `localhost` only and add `authentication: token` on the inter-process link.
+
+3. **`unguarded-access-from-internet`** — STRIDE: **E (Elevation of Privilege)** — The Admin Endpoint is directly reachable from the Internet trust boundary with only a JWT role claim as the gate — no IP allowlist, no WAF, no second factor. A forged or stolen admin token grants immediate access to all user management operations. Mitigation: place admin routes behind a network-level control (IP allowlist or VPN) and enforce MFA for any account that can obtain an admin-role token.
+
+### Reflection
+
+The focused auth model surfaced three classes of risk that the architecture-level baseline missed entirely: SQL injection in the admin path (because the baseline model has no database communication links at all), SSRF on the internal token-signing call (because the baseline treats Juice Shop as a single monolithic asset), and unguarded direct internet access to the admin endpoint (because the baseline's trust boundaries don't distinguish between user and admin routes). Feature-level threat models force you to draw the communication links that matter for a specific flow, which reveals intra-component attack surfaces that an architecture overview deliberately abstracts away.


### PR DESCRIPTION
## Goal

STRIDE-based threat model of OWASP Juice Shop with Threagile: baseline model analysis, hardened secure variant, and a focused auth-flow model from scratch.

## Changes

- `labs/lab2/threagile-model-secure.yaml` - hardened variant with HTTPS on all links, encrypted storage, token auth on proxy-to-app link, and prepared statements declaration
- `labs/lab2/threagile-model-auth.yaml` - auth-flow focused model written from scratch (browser, auth API, token signer, credential store, admin endpoint)
- `submissions/lab2.md` - risk count tables, STRIDE mapping, baseline-vs-secure diff, 3 fixed rules, 2 still-firing rules, honesty check, bonus auth-flow analysis

## Testing

```bash
# Baseline
docker run --rm -v "$(pwd)/labs/lab2":/app/work \
  threagile/threagile:0.9.1 \
  -model /app/work/threagile-model.yaml \
  -output /app/work/output \
  -generate-risks-excel=false -generate-tags-excel=false
# 23 risks (4 elevated, 14 medium, 5 low)

# Secure variant
docker run --rm -v "$(pwd)/labs/lab2":/app/work \
  threagile/threagile:0.9.1 \
  -model /app/work/threagile-model-secure.yaml \
  -output /app/work/output-secure \
  -generate-risks-excel=false -generate-tags-excel=false
# 19 risks (1 elevated, 13 medium, 5 low), delta -4

# Auth flow model
docker run --rm -v "$(pwd)/labs/lab2":/app/work \
  threagile/threagile:0.9.1 \
  -model /app/work/threagile-model-auth.yaml \
  -output /app/work/output-auth \
  -generate-risks-excel=false -generate-tags-excel=false
# 40 risks (2 high, 11 elevated, 22 medium, 5 low)
```

## Artifacts & Screenshots

- [`submissions/lab2.md`](submissions/lab2.md)
- [`labs/lab2/threagile-model-secure.yaml`](labs/lab2/threagile-model-secure.yaml)
- [`labs/lab2/threagile-model-auth.yaml`](labs/lab2/threagile-model-auth.yaml)

---

- [x] Title is clear (`feat(labN): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab2.md` exists
