### PR TITLE
feat(lab1): juice shop deploy + PR template + triage report

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Goal
+<!-- One sentence describing what this PR delivers -->
+
+## Changes
+<!-- Bullet list of files added or modified -->
+- 
+
+## Testing
+<!-- Commands you ran and the output you observed -->
+
+## Artifacts & Screenshots
+<!-- Links to files in this PR; embed screenshots where useful -->
+- 
+
+---
+
+- [ ] Title follows `feat(labN): <topic>` style
+- [ ] No secrets or large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,34 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Start Juice Shop
+        run: |
+          docker run -d --name juice-shop \
+            -p 127.0.0.1:3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for Juice Shop to be ready
+        run: |
+          for i in $(seq 1 30); do
+            curl --silent --fail http://127.0.0.1:3000/rest/admin/application-version >/dev/null && echo "Juice Shop is up!" && exit 0
+            echo "Attempt $i failed, waiting 2s..."
+            sleep 2
+          done
+          echo "Juice Shop never became healthy"
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:3000

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -1,0 +1,79 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+- Asset: OWASP Juice Shop (local lab instance)
+- Image: `bkimminich/juice-shop:v20.0.0`
+- Image digest: `sha256:e791a8e05ad422cf6fdf45105294726e7ca938dff538f7dde1d9fd886426b8f9`
+- Host OS: macOS Tahoe 26.2 (25C56)
+- Docker version: Docker version 27.x (run `docker --version` and update)
+
+### Deployment Details
+- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+- Access URL: http://127.0.0.1:3000
+- Network exposure: 127.0.0.1 only? [x] Yes [ ] No
+- Container restart policy: default (`no` — no `--restart` flag was passed)
+
+### Health Check
+- HTTP code on `/`: 200
+- API check (`/api/Products` product count): 46 products returned
+- Container uptime:
+  ```
+  NAMES        STATUS         PORTS
+  juice-shop   Up 6 minutes   127.0.0.1:3000->3000/tcp
+  ```
+
+### Initial Surface Snapshot (from browser exploration)
+- Login/Registration visible: [x] Yes [ ] No — notes: Login and Register options available under the Account menu (top-right corner)
+- Product listing/search present: [x] Yes [ ] No — notes: Homepage displays product catalog with search functionality
+- Admin or account area discoverable: [x] Yes [ ] No — notes: Account menu visible in top-right; admin panel discoverable via navigation
+- Client-side errors in DevTools console: [ ] Yes [x] No — notes: Console is clean, no red errors observed
+- Pre-populated local storage / cookies: None — Local Storage is empty on first load before any login
+
+### Security Headers (Quick Look)
+
+```
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+Feature-Policy: payment 'self'
+X-Recruiting: /#/jobs
+Accept-Ranges: bytes
+Cache-Control: public, max-age=0
+Last-Modified: Tue, 09 Jun 2026 22:29:50 GMT
+ETag: W/"26af-19eae819e8a"
+Content-Type: text/html; charset=UTF-8
+Content-Length: 9903
+Vary: Accept-Encoding
+Date: Tue, 09 Jun 2026 22:35:57 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+```
+
+Which of these are MISSING?
+- [x] `Content-Security-Policy` — **MISSING**
+- [x] `Strict-Transport-Security` — **MISSING**
+- [ ] `X-Content-Type-Options: nosniff` — present
+- [ ] `X-Frame-Options` — present (SAMEORIGIN)
+
+### Top 3 Risks Observed
+
+1. **Missing Content-Security-Policy (CSP)** — The absence of a CSP header means the browser will execute any inline scripts or load resources from any origin without restriction. This makes the application highly susceptible to Cross-Site Scripting (XSS) attacks, where an attacker can inject malicious scripts that run in a victim's browser. Maps to **A03:2025 – Injection**.
+
+2. **Wildcard CORS (`Access-Control-Allow-Origin: *`)** — The server allows any external origin to make cross-origin requests to the API. A malicious website could send requests to Juice Shop on behalf of a logged-in user and read the responses, potentially leaking sensitive data such as user information or order history. Maps to **A01:2025 – Broken Access Control**.
+
+3. **Missing Strict-Transport-Security (HSTS)** — Without HSTS, the application does not instruct browsers to enforce HTTPS connections. This leaves the app vulnerable to protocol downgrade attacks and man-in-the-middle interception where an attacker on the same network could intercept traffic in plaintext. Maps to **A02:2025 – Cryptographic Failures**.
+
+
+## GitHub Community
+
+- Starred: `juice-shop/juice-shop` and `simple-container-com/api`
+- Following: Cre-eD, Naghme98, pierrepicaud, cQu1x, ARCshekin, joraXD, 0xsmk
+
+Stars help bookmark useful projects and signal community trust to maintainers —
+a high star count is often the first thing engineers check before adopting an
+open-source tool. Following teammates and professors surfaces their activity in
+your GitHub feed, which is a real habit in DevSecOps teams where you want
+visibility into what libraries or tools your colleagues are evaluating.

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -77,3 +77,10 @@ a high star count is often the first thing engineers check before adopting an
 open-source tool. Following teammates and professors surfaces their activity in
 your GitHub feed, which is a real habit in DevSecOps teams where you want
 visibility into what libraries or tools your colleagues are evaluating.
+
+## Bonus: CI Smoke Test
+
+- Workflow file: `.github/workflows/lab1-smoke.yml`
+- Trigger: `pull_request` on main
+- PR URL: https://github.com/inno-devops-labs/DevSecOps-Intro/pull/934
+- Note: Checks tab shows 0 — Actions may be disabled for fork PRs on this repo


### PR DESCRIPTION
## Goal
Deploys OWASP Juice Shop locally, adds triage report, PR template, and CI smoke test.

## Changes
- `.github/PULL_REQUEST_TEMPLATE.md` — PR template for all future labs
- `.github/workflows/lab1-smoke.yml` — CI smoke test workflow
- `submissions/lab1.md` — triage report with deployment details and surface observations

## Testing
- `docker ps` confirmed juice-shop running on 127.0.0.1:3000
- `curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:3000` returned HTTP 200
- `/api/Products` returned 46 products
- `/rest/admin/application-version` returned `{"version": "20.0.0"}`

## Artifacts & Screenshots
- `submissions/lab1.md` — full triage report

---

- [x] Title follows `feat(labN): <topic>` style
- [x] No secrets or large temp files committed
- [x] Submission file at `submissions/lab1.md` exists