### PR TITLE
feat(lab1):  Deploy OWASP Juice Shop & Set Up the Course Workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Goal
+<!-- One sentence: what this PR delivers -->
+
+## Changes
+<!-- Bullet list of files added/changed -->
+-
+
+## Testing
+<!-- How you verified it works: commands + observed output -->
+
+## Artifacts & Screenshots
+<!-- Links to files in this PR, screenshots where useful -->
+-
+
+### Checklist
+- [ ] Title is clear (feat(labN): <topic> style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at submissions/labN.md exists

--- a/.github/workflows/lab01-smoke.yml
+++ b/.github/workflows/lab01-smoke.yml
@@ -1,0 +1,31 @@
+name: lab01-smoke
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start Juice Shop
+        run: |
+          docker run -d --name juice-shop -p 3000:3000 bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for Juice Shop to be healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://localhost:3000/rest/admin/application-version >/dev/null; then
+              echo "Juice Shop is up after ~$((i * 2))s"
+              curl -i http://localhost:3000/rest/admin/application-version
+              exit 0
+            fi
+            echo "Attempt $i: not ready yet, sleeping 2s..."
+            sleep 2
+          done
+          echo "Juice Shop did not become healthy within timeout"
+          docker logs juice-shop
+          exit 1

--- a/submissions/lab01.md
+++ b/submissions/lab01.md
@@ -1,0 +1,62 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+- Asset: OWASP Juice Shop (local lab instance)
+- Image: `bkimminich/juice-shop:v20.0.0`
+- Image digest: <sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0>
+- Host OS: <macOS 14.8.3>
+- Docker version: <29.2.1, build a5c7197>
+
+### Deployment Details
+- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+- Access URL: http://127.0.0.1:3000
+- Network exposure: 127.0.0.1 only? [x] Yes [ ] No 
+- Container restart policy: <default (no)>
+
+### Health Check
+- HTTP code on `/`: <200>
+- Version check output: {"version":"20.0.0"}
+- Container uptime:
+      NAMES        STATUS         PORTS
+      juice-shop   Up 10 minutes  127.0.0.1:3000->3000/tcp
+
+### Initial Surface Snapshot (from browser exploration)
+- Login/Registration visible: [x] Yes [ ] No — notes: <Account -> Login; "Not yet a customer?" = Registration>
+- Product listing/search present: [x] Yes [ ] No — notes: <All Products grid + search icon>
+- Admin or account area discoverable: [x] Yes [ ] No — notes: <Account menu>
+- Client-side errors in DevTools console: [ ] Yes [x] No
+- Pre-populated local storage / cookies: Local Storage empty; one cookie language=en with no Secure/HttpOnly/SameSite flags
+
+### Security Headers (Quick Look)
+Present:
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: SAMEORIGIN
+Missing:
+- Content-Security-Policy
+- Strict-Transport-Security
+
+Top 3 Risks Observed
+1. No Content-Security-Policy header. Without a CSP the browser has no allow-list for scripts, so any injected JavaScript (XSS) would just run. OWASP Top 10:2025 — A06 (Security Misconfiguration).
+2. No Strict-Transport-Security (HSTS) header. The app does not force HTTPS, so the connection could be downgraded and traffic read in plain text. OWASP Top 10:2025 — A02 (Cryptographic Failures).
+3. The exact app version is exposed to anyone at /rest/admin/application-version (it returned 20.0.0). Knowing the precise version makes it easy to look up matching public exploits. OWASP Top 10:2025 — A06 (Security Misconfiguration).
+
+
+## PR Template Setup
+
+- File: `.github/PULL_REQUEST_TEMPLATE.md`
+- Sections included: Goal / Changes / Testing / Artifacts & Screenshots
+- Checklist items: <clear title / no secrets / submission file exists>
+- Auto-fill verified: [ ] Yes — PR description showed my template (screenshot or link to draft PR)
+
+## GitHub Community
+"Starring" lets me bookmark interesting projects so I can find them again later, and the star count is a quick signal of how popular and active a project is. Following other developers helps me see what they are working on, and in a class team it is an easy way to keep track of classmates' work so it is simpler to team up on the next labs.
+
+## Bonus: CI Smoke Test
+
+- Workflow file: `.github/workflows/lab1-smoke.yml`
+- Trigger: `pull_request` on main
+- Run URL (must be green): <link to your Actions run>
+- Workflow run duration: <e.g. 45s>
+- Curl response excerpt:

--- a/submissions/lab01.md
+++ b/submissions/lab01.md
@@ -57,6 +57,12 @@ Top 3 Risks Observed
 
 - Workflow file: `.github/workflows/lab1-smoke.yml`
 - Trigger: `pull_request` on main
-- Run URL (must be green): <link to your Actions run>
-- Workflow run duration: <e.g. 45s>
+- Run URL (must be green): <https://github.com/Nik-ari-ai/DevSecOps-Intro/actions/runs/27270463301>
+- Workflow run duration: <~15s>
 - Curl response excerpt:
+      Juice Shop is up after ~4s
+      HTTP/1.1 200 OK
+      X-Content-Type-Options: nosniff
+      X-Frame-Options: SAMEORIGIN
+      Content-Type: application/json; charset=utf-8
+      {"version":"20.0.0"}


### PR DESCRIPTION
## Goal
Deploy OWASP Juice Shop (the course's canonical attack target), produce a triage report, and bootstrap the PR-driven submission workflow you'll use for every subsequent lab.

## Changes
- submissions/lab01.md — triage report (deployment, surface snapshot, security headers, top 3 risks)
- .github/PULL_REQUEST_TEMPLATE.md — PR template
- .github/workflows/lab01-smoke.yml — CI smoke test for Juice Shop

## Testing
- docker run + curl returned HTTP 200 and {"version":"20.0.0"}
- CI smoke test passed green: Juice Shop up after ~4s, HTTP/1.1 200 OK
- Run: https://github.com/Nik-ari-ai/DevSecOps-Intro/actions/runs/27270463301

## Artifacts & Screenshots
- submissions/lab01.md
- .github/workflows/lab01-smoke.yml

### Checklist
- [x] Task 1 done — Juice Shop deployed, triage report in submissions/lab1.md
- [x] Task 2 done — .github/PULL_REQUEST_TEMPLATE.md created
- [x] Task 3 done — GitHub stars + follows complete
- [x] Bonus done — lab1-smoke.yml runs green on this PR