### PR TITLE
feat(lab2): Threat Modeling: STRIDE on Juice Shop with Threagile

### DIFF
--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,333 @@
+threagile_version: 1.0.0
+title: Juice Shop Auth Flow
+date: 2026-06-10
+author:
+  name: Nik-ari-ai
+business_criticality: important
+questions: {}
+abuse_cases: {}
+security_requirements: {}
+tags_available: []
+
+data_assets:
+
+  Credentials:
+    id: credentials
+    description: User login credentials (username and password)
+    usage: business
+    tags: []
+    origin: User
+    owner: Lab Owner
+    quantity: many
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Account takeover if leaked.
+
+  JWT Token:
+    id: jwt-token
+    description: Signed JWT issued after login and sent on each request
+    usage: business
+    tags: []
+    origin: Auth API
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Session impersonation if stolen or forged.
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: Secret key used to sign and verify JWTs
+    usage: business
+    tags: []
+    origin: Token Service
+    owner: Lab Owner
+    quantity: very-few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Full auth bypass if the signing key leaks.
+
+  Session State:
+    id: session-state
+    description: User session state derived from the JWT
+    usage: business
+    tags: []
+    origin: Auth API
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: Session data exposure.
+
+  Admin Request:
+    id: admin-request
+    description: Privileged admin operation requested with an admin-role JWT
+    usage: business
+    tags: []
+    origin: User
+    owner: Lab Owner
+    quantity: few
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Privilege escalation if admin checks are weak.
+
+technical_assets:
+
+  User Browser:
+    id: browser
+    description: End-user browser
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: true
+    justification_out_of_scope: User-controlled client.
+    size: component
+    technology: browser
+    tags: []
+    internet: true
+    machine: physical
+    encryption: none
+    owner: User
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: Standard browser client.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - admin-request
+    data_assets_stored:
+      - jwt-token
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login Request:
+        target: auth-api
+        description: User submits credentials to log in or register
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+          - session-state
+      Authenticated Request:
+        target: auth-api
+        description: Browser calls protected API with JWT in Authorization header
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - session-state
+      Admin Request Flow:
+        target: admin-endpoint
+        description: Browser calls admin endpoint, JWT must carry admin role
+        protocol: https
+        authentication: token
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-request
+        data_assets_received:
+          - session-state
+
+  Auth API:
+    id: auth-api
+    description: Authentication API (login, register, JWT issuance)
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-service-rest
+    tags: []
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Handles credentials and issues tokens.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Sign Token:
+        target: token-service
+        description: Auth API asks the token service to sign a new JWT
+        protocol: https
+        authentication: credentials
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+      Verify Credentials:
+        target: cred-store
+        description: Auth API checks submitted credentials against the user store
+        protocol: https
+        authentication: credentials
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - credentials
+
+  Token Service:
+    id: token-service
+    description: Signs and verifies JWTs using the signing key
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-server
+    tags: []
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Holds the JWT signing key.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - jwt-signing-key
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Credential Store:
+    id: cred-store
+    description: User database storing credential hashes
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: database
+    tags: []
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Stores all user credentials.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - credentials
+    data_assets_stored:
+      - credentials
+    data_formats_accepted: []
+    communication_links: {}
+
+  Admin Endpoint:
+    id: admin-endpoint
+    description: Privileged admin API requiring an admin-role JWT
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-service-rest
+    tags: []
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: Performs privileged operations.
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - admin-request
+      - jwt-token
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+trust_boundaries:
+
+  Internet:
+    id: internet-boundary
+    description: Untrusted internet zone
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - browser
+    trust_boundaries_nested:
+      - container-boundary
+
+  Container Network:
+    id: container-boundary
+    description: Application container network
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - auth-api
+      - token-service
+      - cred-store
+      - admin-endpoint
+    trust_boundaries_nested: []

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Local Lab Threat Model  
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app (HTTP on 3000)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app (HTTP on 3000 internally)."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js, Express). Uses parameterized queries (prepared statements) for all database access."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTP POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab02.md
+++ b/submissions/lab02.md
@@ -1,0 +1,89 @@
+## Task 1: Baseline Threat Model
+
+### Risk count by severity
+| Severity | Count |
+|----------|------:|
+| Critical | <0> |
+| High | <0> |
+| Elevated | <4> |
+| Medium | <14> |
+| Low | <5> |
+| **Total** | <23> |
+
+### Top 5 risks (paste from `jq` output)
+1. **<issing-authentication>** — <Missing Authentication covering communication link "To App" from Reverse Proxy to Juice Shop Application>; severity <elevated>; affecting <juice-shop>
+2. **<cross-site-scripting>** — <Cross-Site Scripting (XSS) risk at Juice Shop Application; severity elevated>; severity <elevated>; affecting <juice-shop>
+3. **<unencrypted-communication>** — <Unencrypted Communication named "To App" between Reverse Proxy and Juice Shop Application>; severity <elevated>; affecting <reverse-proxy>
+4. **<unencrypted-communication>** — <nencrypted Communication named "Direct to App (no proxy)" between User Browser and Juice Shop Application transferring authentication data (credentials, token, session-id, etc.)>; severity <elevated>; affecting <user-browser>
+5. **<missing-build-infrastructure>** — <Missing Build Infrastructure in the threat model (referencing asset Juice Shop Application as an example)>; severity <medium>; affecting <juice-shop>
+
+### STRIDE mapping (Lecture 2 slide 7)
+For each top-5 risk, name the STRIDE letter(s) it primarily violates:
+- Risk 1: **<S>** — <with no authentication on the link, anyone can call the app pretending to be the proxy.>
+- Risk 2: **T** — XSS injects attacker JavaScript that alters what runs in the victim's browser (also leaks data, so partly I).
+- Risk 3: **I** — proxy→app traffic in clear text can be sniffed on the host network.
+- Risk 4: **I** — credentials and session tokens travel in clear text and can be captured, then replayed (which becomes Spoofing).
+- Risk 5: **T** — without a hardened build pipeline, build artifacts can be tampered with before deployment.
+
+### Trust boundary observation
+Looking at `data-flow-diagram.png`, name one arrow crossing a trust boundary that
+appears in your top-5 risks. Why is that arrow particularly attractive to an attacker?
+Arrow "Direct to App (no proxy)" from User Browser to Juice Shop Application goes from the Internet boundary into the Container Network boundary, and is labeled `http` (no TLS). It is attractive to an attacker because login credentials and session tokens travel over an untrusted network in clear text — anyone able to observe the traffic can capture and reuse them.
+
+## Task 2: Secure Variant & Diff
+
+### Risk count comparison
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | <0> | <0> | <0-0=0> |
+| High | <0> | <0> | <0-0=0> |
+| Elevated | <4> | <2> | <2-4=-2> |
+| Medium | <14> | <13> | <13-14=-1> |
+| Low | <5> | <5> | <5-5=0> |
+| **Total** | <23> | <20> | <20-23=-3> |
+
+### Which rules are GONE in the secure variant?
+List 3 rule IDs that fired in baseline but not in secure-variant:
+1. `<unencrypted-communication>` — fixed by `<changing the link `protocol` from `http` to `https`>` (Reverse Proxy → Juice Shop App, "To App")
+2. `<unencrypted-communication>` — fixed by `<changing the link `protocol` from `http` to `https`>`(User Browser → Juice Shop App, "Direct to App")
+3. `<unencrypted-asset>` — fixed by `<setting the technical asset's `encryption` from `none` to `data-with-symmetric-shared-key`>`
+
+### Which rules are STILL THERE in the secure variant?
+Threat modeling never reaches zero risk. List 2 rules that still fire and explain why
+your changes didn't eliminate them (2-3 sentences each).
+1. `missing-authentication` — Encrypting the channel (TLS) does not add identity checks. The communication links still have `authentication: none`, so any caller can talk to the app pretending to be the proxy. TLS protects data in transit but not who the caller is.
+2. `cross-site-scripting` — XSS is a code-level flaw in how the app handles user input. No YAML field can remove it; it would require input validation and output encoding in the application code, which is outside what the threat model can express.
+
+
+
+### Honesty check
+Did the total drop more than 50%? If yes, what does that say about the cost-benefit
+of these particular hardening changes vs. the work you'd need to fully eliminate the rest?
+No — the total dropped from 23 to 20 (about 13%). One-line hardening of transport (TLS) and storage (encryption-at-rest) gives a few high-value wins, but most remaining findings — missing-authentication, missing-waf, missing-vault, missing-identity-store, XSS, CSRF, SSRF, hardening, build-infrastructure — are architectural and code-level problems that need real engineering work (adding components, changing code, designing identity propagation). Cheap field toggles in the YAML cannot replace that work.
+
+## Bonus Task: Auth Flow Threat Model
+
+### Risk count
+| Severity | Count |
+|----------|------:|
+| Critical | <0> |
+| High | <1> |
+| Elevated | <8> |
+| Medium | <19> |
+| Low | <5> |
+| **Total** | 33> |
+
+### Three auth-specific risks (NOT in the baseline model's top 5)
+For each, name:
+- The rule ID Threagile fires
+- The STRIDE letter
+- A 1-2 sentence mitigation in plain English
+
+1. **<sql-nosql-injection>** — STRIDE: <T> — Mitigation: <ban string concatenation in queries to the credential store; use parameterized queries everywhere and validate input shape on the auth endpoint>
+2. **<missing-identity-propagation>** — STRIDE: <E> — Mitigation: <propagate the end-user identity from the auth API down to Token Service and Admin Endpoint, and re-check authorization at each layer (defense-in-depth) instead of trusting the perimeter alone>
+3. **<unguarded-access-from-internet>** — STRIDE: <S> — Mitigation: <put a WAF/rate-limit in front of the auth endpoint and close direct internet exposure of internal services so credential stuffing and forged requests are harder>
+
+### Reflection (2-3 sentences)
+What did building the focused model surface that the baseline architecture model missed?
+(Hint: feature-level threat models often find what architecture-level ones can't.)
+The focused auth-only model surfaced flow-specific risks that the broad architecture model missed: injection on the credential store, lack of identity propagation between internal services, and direct internet exposure of the auth endpoint. When the model is small and scoped to one feature, the tool actually exercises that path instead of drowning the same checks in noise from unrelated components.


### PR DESCRIPTION
## Goal
Generate a STRIDE-based threat model of OWASP Juice Shop with Threagile, then produce a secure-variant model and diff the risk reports.

## Changes
- submissions/lab02.md — risk count tables, top-5 + STRIDE mapping, secure-variant diff, auth-flow risks and reflection
- labs/lab2/threagile-model-secure.yaml — hardened variant of the baseline model (http->https on 2 links, encrypted file-server, prepared-statements declared in description)
- labs/lab2/threagile-model-auth.yaml — new auth-flow model (5 assets, 5 data assets, 5 links, 2 trust boundaries)

## Testing
- Threagile 0.9.1 ran on all three models, risks.json generated for each
- Baseline: 0 critical / 0 high / 4 elevated / 14 medium / 5 low = 23
- Secure variant: 0 / 0 / 2 / 13 / 5 = 20 (-3, three unencrypted-* rules gone)
- Auth flow: 0 / 1 / 8 / 19 / 5 = 33 (new rule IDs vs baseline: sql-nosql-injection, missing-identity-propagation, unguarded-access-from-internet)

## Artifacts & Screenshots
- submissions/lab02.md
- labs/lab2/threagile-model-secure.yaml
- labs/lab2/threagile-model-auth.yaml

### Checklist
- [x] Task 1 — Baseline risk table + top-5 with STRIDE mapping
- [x] Task 2 — Secure variant + risk diff table
- [x] Bonus — Auth-flow model + 3 auth-specific risks