### PR TITLE
feat(lab2): Threagile threat model + secure variant

### DIFF
--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,431 @@
+﻿threagile_version: 1.0.0
+
+title: OWASP Juice Shop â€” Local Lab Threat Model  
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A userâ€™s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the hostâ€™s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) â†’ **Host** (local machine/VM) â†’ **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other usersâ€™ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) â€“ keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains usersâ€™ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs; secure variant disables plain sensitive log writes and requires sanitization/encrypted storage."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app (HTTP on 3000)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app (HTTP on 3000 internally)."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v20.0.0). Secure variant declares parameterized queries / prepared statements for database access and avoids plain sensitive log writes. Secure variant declares parameterized queries / prepared statements for database access and avoids plain sensitive log writes."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTP POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container â€“ not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true
+
+

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,83 @@
+﻿# Lab 2 — Submission
+
+## Task 1: Baseline Threat Model
+
+### Risk count by severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | 23 |
+
+### Top 5 risks
+
+1. **cross-site-scripting@juice-shop** — Cross-Site Scripting (XSS) risk at Juice Shop Application; severity Elevated; affecting Juice Shop Application.
+2. **missing-authentication@reverse-proxy>to-app@reverse-proxy@juice-shop** — Missing Authentication covering communication link To App from Reverse Proxy to Juice Shop Application; severity Elevated; affecting Juice Shop Application / Reverse Proxy communication.
+3. **unencrypted-communication@user-browser>direct-to-app-no-proxy@user-browser@juice-shop** — Unencrypted Communication named Direct to App (no proxy) between User Browser and Juice Shop Application transferring authentication data; severity Elevated; affecting User Browser → Juice Shop Application.
+4. **unencrypted-communication@reverse-proxy>to-app@reverse-proxy@juice-shop** — Unencrypted Communication named To App between Reverse Proxy and Juice Shop Application; severity Elevated; affecting Reverse Proxy → Juice Shop Application.
+5. **container-baseimage-backdooring@juice-shop** — Container Base Image Backdooring risk at Juice Shop Application; severity Medium; affecting Juice Shop Application.
+
+### STRIDE mapping
+
+- Risk 1: **T — Tampering.** XSS allows attacker-controlled script execution that can modify browser-side behavior and user-visible data.
+- Risk 2: **E — Elevation of Privilege.** Missing authentication on an application communication path can allow unauthorized access to protected functionality or data.
+- Risk 3: **I — Information Disclosure.** Unencrypted direct user-to-app traffic can expose credentials, tokens, or session identifiers in transit.
+- Risk 4: **I — Information Disclosure.** Unencrypted proxy-to-app communication can expose sensitive data moving between internal components.
+- Risk 5: **T — Tampering.** A backdoored container base image can introduce unauthorized code or alter application runtime behavior.
+
+### Trust boundary observation
+
+One trust-boundary-crossing arrow visible in the data-flow diagram is **User Browser → Juice Shop Application** via **Direct to App (no proxy)**. This arrow is attractive to an attacker because it crosses from the Internet/user-controlled side into the application container and transfers authentication/session data. If the link is unencrypted or weakly protected, it becomes a high-value place for credential theft, session interception, and request manipulation.
+
+## Task 2: Secure Variant & Diff
+
+### Risk count comparison
+
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 2 | -2 |
+| Medium | 14 | 13 | -1 |
+| Low | 5 | 5 | 0 |
+| **Total** | 23 | 20 | -3 |
+
+### Which rules are GONE in the secure variant?
+
+1. `unencrypted-communication@user-browser>direct-to-app-no-proxy@user-browser@juice-shop` — fixed by changing direct browser-to-application traffic from HTTP to HTTPS.
+2. `unencrypted-communication@reverse-proxy>to-app@reverse-proxy@juice-shop` — fixed by changing reverse-proxy-to-application traffic to HTTPS.
+3. One `unencrypted-technical-assets` finding was reduced by declaring encrypted storage for the persistent storage asset.
+
+### Which rules are STILL THERE in the secure variant?
+
+1. `cross-site-scripting@juice-shop` — still present because enabling HTTPS and storage encryption does not automatically sanitize output, encode user-controlled content, or remove DOM/browser-side injection risks. This still requires development-side XSS controls.
+2. `missing-authentication@reverse-proxy>to-app@reverse-proxy@juice-shop` — still present because transport encryption does not create an authentication or authorization mechanism. The model still needs explicit authentication/identity controls for sensitive application paths.
+3. `missing-vault@juice-shop` — still present because encrypted communication/storage does not introduce a dedicated secrets-management component. A vault or equivalent secret storage design would be a separate architectural control.
+
+### Honesty check
+
+The total risk count dropped from **23** to **20**, which is about **13.0%**. This is less than 50%, so the secure-variant changes are useful but not a complete fix. HTTPS, encrypted storage, prepared statements, and log hardening remove several obvious infrastructure weaknesses, but the remaining risks show that authentication, identity-store modeling, WAF placement, container hardening, secrets management, and application-level validation still require additional work.
+
+## Commands used
+
+```powershell
+docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model.yaml -output /app/work/output -generate-risks-excel=false -generate-tags-excel=false
+
+docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure -generate-risks-excel=false -generate-tags-excel=false
+
+## Generated artifacts
+
+- Baseline model: `labs/lab2/threagile-model.yaml`
+- Secure model: `labs/lab2/threagile-model-secure.yaml`
+- Baseline report generated locally: `labs/lab2/output/report.pdf`
+- Secure report generated locally: `labs/lab2/output-secure/report.pdf`
+- Baseline JSON report: `labs/lab2/output/risks.json`
+- Secure JSON report: `labs/lab2/output-secure/risks.json`
+
+## Note on Excel output
+
+`risks.xlsx` generation was disabled with `-generate-risks-excel=false` / `-generate-tags-excel=false` because the local Threagile XLSX generation failed on an Excel worksheet name length limit. PDF, JSON, and diagram generation completed successfully, and the risk counts were verified from the generated PDF reports and `risks.json`.

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -17,8 +17,8 @@
 
 1. **cross-site-scripting@juice-shop** — Cross-Site Scripting (XSS) risk at Juice Shop Application; severity Elevated; affecting Juice Shop Application.
 2. **missing-authentication@reverse-proxy>to-app@reverse-proxy@juice-shop** — Missing Authentication covering communication link To App from Reverse Proxy to Juice Shop Application; severity Elevated; affecting Juice Shop Application / Reverse Proxy communication.
-3. **unencrypted-communication@user-browser>direct-to-app-no-proxy@user-browser@juice-shop** — Unencrypted Communication named Direct to App (no proxy) between User Browser and Juice Shop Application transferring authentication data; severity Elevated; affecting User Browser → Juice Shop Application.
-4. **unencrypted-communication@reverse-proxy>to-app@reverse-proxy@juice-shop** — Unencrypted Communication named To App between Reverse Proxy and Juice Shop Application; severity Elevated; affecting Reverse Proxy → Juice Shop Application.
+3. **unencrypted-communication@user-browser>direct-to-app-no-proxy@user-browser@juice-shop** — Unencrypted Communication named Direct to App (no proxy) between User Browser and Juice Shop Application transferring authentication data; severity Elevated; affecting User Browser to Juice Shop Application.
+4. **unencrypted-communication@reverse-proxy>to-app@reverse-proxy@juice-shop** — Unencrypted Communication named To App between Reverse Proxy and Juice Shop Application; severity Elevated; affecting Reverse Proxy to Juice Shop Application.
 5. **container-baseimage-backdooring@juice-shop** — Container Base Image Backdooring risk at Juice Shop Application; severity Medium; affecting Juice Shop Application.
 
 ### STRIDE mapping
@@ -31,7 +31,7 @@
 
 ### Trust boundary observation
 
-One trust-boundary-crossing arrow visible in the data-flow diagram is **User Browser → Juice Shop Application** via **Direct to App (no proxy)**. This arrow is attractive to an attacker because it crosses from the Internet/user-controlled side into the application container and transfers authentication/session data. If the link is unencrypted or weakly protected, it becomes a high-value place for credential theft, session interception, and request manipulation.
+One trust-boundary-crossing arrow visible in the data-flow diagram is **User Browser to Juice Shop Application** via **Direct to App (no proxy)**. This arrow is attractive to an attacker because it crosses from the Internet/user-controlled side into the application container and transfers authentication/session data. If the link is unencrypted or weakly protected, it becomes a high-value place for credential theft, session interception, and request manipulation.
 
 ## Task 2: Secure Variant & Diff
 
@@ -82,5 +82,3 @@ docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model
 ## Note on Excel output
 
 `risks.xlsx` generation was disabled with `-generate-risks-excel=false` / `-generate-tags-excel=false` because the local Threagile XLSX generation failed on an Excel worksheet name length limit. PDF, JSON, and diagram generation completed successfully, and the risk counts were verified from the generated PDF reports and `risks.json`.
-
-

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -81,3 +81,4 @@ docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model
 ## Note on Excel output
 
 `risks.xlsx` generation was disabled with `-generate-risks-excel=false` / `-generate-tags-excel=false` because the local Threagile XLSX generation failed on an Excel worksheet name length limit. PDF, JSON, and diagram generation completed successfully, and the risk counts were verified from the generated PDF reports and `risks.json`.
+

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -68,6 +68,7 @@ The total risk count dropped from **23** to **20**, which is about **13.0%**. Th
 docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model.yaml -output /app/work/output -generate-risks-excel=false -generate-tags-excel=false
 
 docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure -generate-risks-excel=false -generate-tags-excel=false
+```
 
 ## Generated artifacts
 
@@ -81,4 +82,5 @@ docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model
 ## Note on Excel output
 
 `risks.xlsx` generation was disabled with `-generate-risks-excel=false` / `-generate-tags-excel=false` because the local Threagile XLSX generation failed on an Excel worksheet name length limit. PDF, JSON, and diagram generation completed successfully, and the risk counts were verified from the generated PDF reports and `risks.json`.
+
 


### PR DESCRIPTION
## Goal

This PR delivers Lab 2: STRIDE threat modeling for OWASP Juice Shop using Threagile, including baseline risk analysis, secure variant modeling, and risk-count comparison.

## Changes

* Added `submissions/lab2.md`
* Added `labs/lab2/threagile-model-secure.yaml`
* Documented baseline risk counts, top-5 risks, STRIDE mapping, trust-boundary observation, and secure-variant diff

## Testing

Commands used:

```bash
docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model.yaml -output /app/work/output -generate-risks-excel=false -generate-tags-excel=false

docker run --rm -v "<repo>/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure -generate-risks-excel=false -generate-tags-excel=false
```

Observed output:

```text
Baseline report generated: 23 risks.
Secure report generated: 20 risks.
PDF, JSON, and diagrams generated successfully.
Risk count comparison documented in submissions/lab2.md.
```

## Artifacts & Screenshots

* Submission file: `submissions/lab2.md`
* Secure variant model: `labs/lab2/threagile-model-secure.yaml`

## Checklist

* [x] Title is clear: `feat(lab2): Threagile threat model + secure variant`
* [x] No secrets/large temp files committed
* [x] Submission file at `submissions/lab2.md` exists

## Lab checklist

* [x] Task 1 — Baseline risk table + top-5 with STRIDE mapping
* [x] Task 2 — Secure variant + risk diff table
* [ ] Bonus — Auth-flow model + 3 auth-specific risks
