### PR TITLE
feat(lab1): juice shop deploy + PR template + triage report

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Goal
+
+<! What this PR delivers in one sentence. >
+
+## Changes
+
+<! List the files/artifacts added or modified. >
+
+- 
+
+## Testing
+
+<! Describe how you verified the work. Include commands and observed output. >
+
+- 
+
+## Artifacts & Screenshots
+
+<! Link to files in this PR or embed screenshots where useful. >
+
+- 
+
+## Checklist
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,45 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run OWASP Juice Shop
+        run: |
+          docker run -d --name juice-shop \
+            -p 127.0.0.1:3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for Juice Shop to become healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl --silent --fail http://127.0.0.1:3000/rest/admin/application-version; then
+              echo
+              echo "Juice Shop version endpoint is healthy"
+              exit 0
+            fi
+
+            echo "Waiting for Juice Shop... attempt $i/30"
+            sleep 2
+          done
+
+          echo "Juice Shop did not become healthy within 60 seconds"
+          docker logs juice-shop
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          curl --silent --fail --show-error http://127.0.0.1:3000 > /dev/null
+          echo "Homepage returned HTTP 200"

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -69,7 +69,7 @@ Which of these are MISSING? (cross-reference Lecture 1 OWASP Top 10:2025 — A06
   - Title is clear (`feat(labN): <topic>` style)
   - No secrets/large temp files committed
   - Submission file at `submissions/labN.md` exists
-- Auto-fill verified: [ ] Yes — pending until I open a draft PR and GitHub shows the template in the PR description.
+- Auto-fill verified: [ ] No — the template file exists at `.github/PULL_REQUEST_TEMPLATE.md`, but it did not auto-fill for the first PR because this PR introduces the template itself. The PR body was filled manually using the same template structure.
 
 ## GitHub Community
 
@@ -79,6 +79,11 @@ Starring repositories matters in open source because it helps make useful projec
 
 - Workflow file: `.github/workflows/lab1-smoke.yml`
 - Trigger: `pull_request` on `main`
-- Run URL (must be green): pending until the PR is opened and GitHub Actions runs
-- Workflow run duration: pending
-- Curl response excerpt: pending
+- Run URL (must be green): https://github.com/Troshkins/DevSecOps-Intro/actions/runs/27350872180
+- Workflow run duration: 21s
+- Curl response excerpt: 
+Waiting for Juice Shop... attempt 1/30
+{"version":"20.0.0"}
+Juice Shop version endpoint is healthy
+0s
+Homepage returned HTTP 200

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -1,0 +1,84 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+- Asset: OWASP Juice Shop (local lab instance)
+- Image: `bkimminich/juice-shop:v20.0.0`
+- Image digest: sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+- Host OS: Arch Linux, Linux 7.0.10-arch1-1, x86_64
+- Docker version: 29.5.2
+
+### Deployment Details
+- Run command used: `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+- Access URL: http://127.0.0.1:3000
+- Network exposure: 127.0.0.1 only? Yes
+- Container restart policy: No
+
+### Health Check
+- HTTP code on `/`: 200
+- API check (first 200 chars of `/rest/products`): {"status":"success","data":[{"id":1,"name":"Apple Juice (1000ml)","description":"The all-time classic.","price":1.99,"deluxePrice":0.99,"image":"apple_juice.jpg","createdAt":"2026-06-10T21:37:17.403Z"
+- Container uptime: 12 hours
+
+### Initial Surface Snapshot (from browser exploration)
+- Login/Registration visible: Yes
+- Product listing/search present: Yes
+- Admin or account area discoverable: Yes
+- Client-side errors in DevTools console: No
+- Pre-populated local storage / cookies: Before authentication, Local Storage for `http://127.0.0.1:3000` was empty. Cookies were present: `continueCode`, `language=en`, and `welcomebanner_status=dismiss`. After registration/login, a `token` value appeared in both Local Storage and Cookies; the token value was redacted because it is an authentication token.
+
+### Security Headers (Quick Look)
+Run: `curl -I http://127.0.0.1:3000 2>&1 | head -20`. Paste output:
+```  
+% Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
+                                 Dload  Upload  Total   Spent   Left   Speed
+  0   9903   0      0   0      0      0      0                              0
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+Feature-Policy: payment 'self'
+X-Recruiting: /#/jobs
+Accept-Ranges: bytes
+Cache-Control: public, max-age=0
+Last-Modified: Wed, 10 Jun 2026 21:37:19 GMT
+ETag: W/"26af-19eb377e2a7"
+Content-Type: text/html; charset=UTF-8
+Content-Length: 9903
+Vary: Accept-Encoding
+Date: Thu, 11 Jun 2026 09:25:54 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+```
+Which of these are MISSING? (cross-reference Lecture 1 OWASP Top 10:2025 — A06)
+- [X] `Content-Security-Policy`
+- [X] `Strict-Transport-Security`
+- [ ] `X-Content-Type-Options: nosniff`
+- [ ] `X-Frame-Options`
+
+### Top 3 Risks Observed (2-3 sentences each, in your own words)
+1. **Authentication token stored client-side** — After registration/login, a JWT-like `token` appeared in both Local Storage and Cookies. This matters because tokens stored in browser-accessible storage can become high-value targets. This maps to OWASP Top 10:2025 A07 — Identification & Authentication Failures.
+2. **Missing security headers** — The initial HTTP response does not include several browser security headers. This matters because the browser receives fewer built-in protections against attacks. This maps to OWASP Top 10:2025 A06
+3. **Public product and review API surface** — Product data and review-related API calls are visible from the browser Network tab during normal browsing. It expands the attack surface and should be tested later for missing authorization checks, unauthorized data access, and unsafe input handling. This maps to OWASP Top 10:2025 A01 — Broken Access Control.
+
+## PR Template Setup
+
+- File: `.github/PULL_REQUEST_TEMPLATE.md`
+- Sections included: Goal / Changes / Testing / Artifacts & Screenshots
+- Checklist items:
+  - Title is clear (`feat(labN): <topic>` style)
+  - No secrets/large temp files committed
+  - Submission file at `submissions/labN.md` exists
+- Auto-fill verified: [ ] Yes — pending until I open a draft PR and GitHub shows the template in the PR description.
+
+## GitHub Community
+
+Starring repositories matters in open source because it helps make useful projects more visible and also lets me quickly find them later. Following developers is useful for team projects and professional growth because it helps me track their public work, learn from their activity, and stay connected with people from the course.
+
+## Bonus: CI Smoke Test
+
+- Workflow file: `.github/workflows/lab1-smoke.yml`
+- Trigger: `pull_request` on `main`
+- Run URL (must be green): pending until the PR is opened and GitHub Actions runs
+- Workflow run duration: pending
+- Curl response excerpt: pending


### PR DESCRIPTION
## Goal

Set up Lab 1 workflow by deploying OWASP Juice Shop locally, documenting the initial triage report, and adding the reusable PR template.

## Changes

- Added `.github/PULL_REQUEST_TEMPLATE.md`
- Added `submissions/lab1.md` with deployment details, health checks, browser exploration notes, security headers review, and observed risks
- Added `.github/workflows/lab1-smoke.yml` for the bonus CI smoke test

## Testing

- Ran OWASP Juice Shop locally with Docker using localhost-only port binding
- Verified homepage returned HTTP 200
- Verified `/api/Products` returned product data
- Verified application version endpoint returned `20.0.0`
- Checked browser Local Storage and Cookies through DevTools
- Checked security headers with `curl -I http://127.0.0.1:3000`
- Added GitHub Actions smoke test to run Juice Shop and verify it responds in CI

## Artifacts & Screenshots

- Submission report: `submissions/lab1.md`
- PR template: `.github/PULL_REQUEST_TEMPLATE.md`
- Bonus workflow: `.github/workflows/lab1-smoke.yml`

## Checklist

- [x] Title is clear (`feat(labN): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/labN.md` exists