### PR TITLE
feat(lab2): Threagile threat model + secure variant + risk diff

### DIFF
--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Local Lab Threat Model (SECURE VARIANT)
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Hardened variant of the local OWASP Juice Shop threat model. All user and internal
+  traffic is forced over HTTPS/TLS, the host-mounted storage is encrypted at rest, the
+  proxy-to-app link is authenticated, and the application is declared to use
+  parameterized (prepared) statements for database access. Used to diff the risk report
+  against the baseline model.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app, now forced over HTTPS/TLS (was HTTP on 3000)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app over TLS, now mutually authenticated (was plain HTTP on 3000 internally)."
+        protocol: https
+        authentication: client-certificate
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0). Uses parameterized / prepared statements for all database access to prevent SQL injection."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTPS POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs, now encrypted at rest with a symmetric shared key."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,75 @@
+# Lab 2 — Submission
+
+## Task 1: Baseline Threat Model
+
+Tool: Threagile v0.9.1 (Docker image `threagile/threagile:0.9.1`), run against the
+provided `labs/lab2/threagile-model.yaml`. Counts below are taken directly from
+`labs/lab2/output/risks.json`.
+
+### Risk count by severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | **23** |
+
+### Top 5 risks
+
+1. **`cross-site-scripting`** — *Cross-Site Scripting (XSS) risk at Juice Shop Application*; severity **elevated**; asset **juice-shop**.
+2. **`unencrypted-communication`** — *Unencrypted Communication "Direct to App (no proxy)" between User Browser and Juice Shop Application, transferring authentication data (credentials, token, session-id)*; severity **elevated**; asset **user-browser**.
+3. **`unencrypted-communication`** — *Unencrypted Communication "To App" between Reverse Proxy and Juice Shop Application*; severity **elevated**; asset **reverse-proxy**.
+4. **`missing-authentication`** — *Missing Authentication covering communication link "To App" from Reverse Proxy to Juice Shop Application*; severity **elevated**; asset **juice-shop**.
+5. **`missing-waf`** — *Missing Web Application Firewall (WAF)</b> risk at <b>Juice Shop Application*; severity **low**; asset **juice-shop**.
+
+### STRIDE mapping (Lecture 2 slide 7)
+
+- **Risk 1 — XSS:** **T** (Tampering) — attacker-controlled script alters the page rendered in the victim's browser; secondary **I** (Information Disclosure) by stealing session tokens.
+- **Risk 2 — Unencrypted comm carrying credentials:** **I** (Information Disclosure) — cleartext HTTP lets anyone on the path read credentials/session IDs.
+- **Risk 3 — Unencrypted comm proxy→app:** **I** (Information Disclosure) — internal traffic is sniffable; also **T** if an attacker on the host network rewrites it.
+- **Risk 4 — Missing authentication:** **S** (Spoofing) — without auth on the link, a caller can impersonate a legitimate client; secondary **E** (Elevation of Privilege).
+- **Risk 5 — SSRF:** **I** (Information Disclosure) — the app can be coerced into requesting internal resources; secondary **E** by reaching otherwise-protected endpoints.
+
+### Trust boundary observation
+
+In `data-flow-diagram.png`, the **User Browser → Juice Shop Application** arrow (the "Direct to App (no proxy)" link, labelled **`http`**) crosses  wo trust boundaries — **Internet → Host → Container Network** — to reach the app in plain text, carrying authentication data (Risk 2). By contrast, the parallel User Browser → Reverse Proxy arrow is `https`. This unencrypted arrow is especially attractive to an attacker because it is high value and low effort: anyone observing the network path (shared Wi-Fi, compromised router, ARP spoofing) can read credentials and session tokens in  leartext, with no TLS to defeat — instant account takeover without touching application logic.
+
+## Task 2: Secure Variant & Diff
+ 
+Hardened model: `labs/lab2/threagile-model-secure.yaml`. Changes applied (5):
+ 
+1. **HTTPS user→app** — `Direct to App (no proxy)` link `protocol: http → https`.
+2. **TLS proxy→app** — `To App` link `protocol: http → https`.
+3. **Authenticated proxy→app** — `To App` link `authentication: none → client-certificate`, `authorization: none → technical-user`.
+4. **Encrypt at rest** — `persistent-storage` `encryption: none → data-with-symmetric-shared-key`; `juice-shop` `encryption: none → transparent`.
+5. **Prepared statements declared** — note added to the Juice Shop description that all DB access uses parameterized/prepared statements.
+(The outbound WebHook link was already `https` in the baseline, so no change was needed there.)
+ 
+### Risk count comparison
+ 
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 1 | −3 |
+| Medium | 14 | 12 | −2 |
+| Low | 5 | 5 | 0 |
+| **Total** | **23** | **18** | **−5** |
+ 
+### Which rules are GONE in the secure variant?
+ 
+1. **`unencrypted-communication`** (elevated, ×2) — fixed by setting `protocol: https` on both the `Direct to App (no proxy)` and `To App` links.
+2. **`missing-authentication`** (elevated, ×1) — fixed by adding `authentication: client-certificate` + `authorization: technical-user` to the `To App` link.
+3. **`unencrypted-asset`** (medium, ×2) — fixed by `encryption: data-with-symmetric-shared-key` on `persistent-storage` and `transparent` on `juice-shop`.
+ 
+### Which rules are STILL THERE in the secure variant?
+ 
+1. **`cross-site-scripting`** (elevated) — still fires because XSS is an application-code defect. Encrypting transport and storage or authenticating links does nothing for content rendered in the victim's browser, only code-level fixes in the app remove it.
+2. **`server-side-request-forgery`** (medium, ×2) — still fires because the app still issues outbound requests. SSRF is about the app validating where it connects; switching that link to HTTPS encrypts the call but doesn't stop the app being coerced into reaching internal resources.
+ 
+### Honesty check
+ 
+The total dropped from 23 to 18 — about **−22%**, so not more than 50%.


### PR DESCRIPTION
## Goal
Generate a STRIDE threat model of Juice Shop with Threagile, produce a hardened variant, and diff the risk reports.

## Changes
- `labs/lab2/threagile-model-secure.yaml` — hardened model (HTTPS, encrypted storage, authenticated proxy→app)
- `submissions/lab2.md` — baseline risk table + top-5 + STRIDE + secure-variant diff

## Testing
- Threagile v0.9.1 baseline → 23 risks (4 elevated / 14 medium / 5 low)
- Secure variant → 18 risks (1 elevated / 12 medium / 5 low), −5 total, elevated −75%

## Artifacts & Screenshots
- `submissions/lab2.md`

---

- [x] Task 1 — Baseline risk table + top-5 with STRIDE mapping
- [x] Task 2 — Secure variant + risk diff table
- [ ] Bonus — Auth-flow model + 3 auth-specific risks