### PR TITLE
Feature/lab2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Goal
+
+Describe what this PR delivers in one sentence.
+
+## Changes
+
+- 
+
+## Testing
+
+- 
+
+## Artifacts & Screenshots
+
+- Submission: `submissions/labN.md`
+- Screenshots or links:
+
+## Checklist
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,440 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop Auth Flow Threat Model
+date: 2026-06-12
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Focused feature-level threat model for the OWASP Juice Shop authentication path:
+  browser login, JWT issuance, token verification, session state, and admin-only API access.
+
+business_criticality: important
+
+business_overview:
+  description: >
+    This model narrows the lab architecture to the authentication and authorization
+    path most relevant to account takeover and privilege escalation.
+  images: []
+
+technical_overview:
+  description: >
+    The browser sends credentials to the Auth API. The Auth API checks the credential
+    store, asks the token component to issue a JWT, and the browser later presents
+    that JWT to protected and admin endpoints. The admin endpoint verifies the token
+    and role claims before serving admin operations.
+  images: []
+
+questions:
+  Are JWT signing keys stored outside application code?: "No; the focused model treats them as app-local secrets."
+  Are admin endpoints protected only by JWT role claims?: "Yes; this model focuses on that authorization decision."
+
+abuse_cases:
+  Token Forgery: >
+    An attacker obtains or guesses a weak JWT signing key and creates an admin token.
+  Credential Stuffing: >
+    An attacker automates login attempts against the Auth API using leaked credentials.
+  Broken Role Check: >
+    An attacker reuses a valid non-admin JWT against admin endpoints and bypasses role checks.
+
+security_requirements:
+  Strong JWT signing keys: Store signing keys in a vault or HSM-backed secret manager and rotate them.
+  Server-side role checks: Verify token signature, expiry, issuer, audience, and admin role on every protected request.
+  Brute-force controls: Rate-limit login attempts and add account lockout or step-up checks after suspicious failures.
+  Prepared credential queries: Use parameterized SQL for all credential lookups.
+
+tags_available:
+  - auth
+  - jwt
+  - pii
+  - admin
+  - credential-store
+  - tokens
+  - actor
+  - browser
+  - app
+  - datastore
+
+data_assets:
+
+  Credentials:
+    id: credentials
+    description: "Username and password submitted during login and registration."
+    usage: business
+    tags: ["auth", "pii"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Credentials must remain confidential and must not be tampered with, because
+      compromise leads directly to account takeover.
+
+  JWT Token:
+    id: jwt-token
+    description: "Issued bearer token used in Authorization headers for protected requests."
+    usage: business
+    tags: ["auth", "jwt", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      A stolen or forged JWT can impersonate a user or administrator.
+
+  Session State:
+    id: session-state
+    description: "Server-side and client-observable session state associated with active logins."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Session state affects account continuity and must not leak or be modified by attackers.
+
+  Admin Operations:
+    id: admin-operations
+    description: "Privileged API requests for administrative Juice Shop functions."
+    usage: business
+    tags: ["admin"]
+    origin: application
+    owner: Lab Owner
+    quantity: few
+    confidentiality: restricted
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Admin operations can change application state and expose sensitive user data.
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: "Secret key used to sign and verify JWTs."
+    usage: business
+    tags: ["auth", "jwt", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: very-few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      If this key leaks or is altered, attackers can forge valid tokens.
+
+technical_assets:
+
+  Browser:
+    id: browser
+    description: "End-user browser presenting credentials and JWT bearer tokens."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "browser"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "The browser is user-controlled and can also represent an attacker."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - session-state
+      - admin-operations
+    data_assets_stored:
+      - jwt-token
+      - session-state
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login To Auth API:
+        target: auth-api
+        description: "Browser sends login/register credentials and receives JWT plus session state over HTTPS."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+          - session-state
+      JWT To Protected API:
+        target: auth-api
+        description: "Browser calls protected API routes with JWT in the Authorization header."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - session-state
+      JWT To Admin API:
+        target: admin-api
+        description: "Browser calls admin endpoint with JWT; endpoint must require admin role claims."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["admin", "jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-operations
+        data_assets_received:
+          - admin-operations
+
+  Auth API:
+    id: auth-api
+    description: "Juice Shop login/register endpoint and protected API gate."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-application
+    tags: ["auth", "app"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Central authentication entry point for credentials and tokens."
+    multi_tenant: true
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Query Credentials:
+        target: credential-store
+        description: "Credential lookup for login; parameterized SQL should be used to avoid injection."
+        protocol: sql-access-protocol
+        authentication: credentials
+        authorization: technical-user
+        tags: ["credential-store"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - credentials
+          - session-state
+      Request JWT:
+        target: token-service
+        description: "Auth API requests token issuance after successful credential verification."
+        protocol: in-process-library-call
+        authentication: none
+        authorization: technical-user
+        tags: ["jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - session-state
+        data_assets_received:
+          - jwt-token
+      Verify Protected JWT:
+        target: token-service
+        description: "Auth API verifies JWT signature and expiry on each protected request before serving user-specific state."
+        protocol: in-process-library-call
+        authentication: token
+        authorization: technical-user
+        tags: ["jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - jwt-token
+
+  Token Service:
+    id: token-service
+    description: "JWT signing and verification component inside the Juice Shop container."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: library
+    tags: ["auth", "jwt"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "The component handles signing keys and token integrity decisions."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - jwt-signing-key
+      - session-state
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Credential Store:
+    id: credential-store
+    description: "SQLite-backed user credential and session store."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: identity-store-database
+    tags: ["credential-store", "datastore"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Stores credentials and session data that enable account takeover if leaked."
+    multi_tenant: true
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - credentials
+      - session-state
+    data_assets_stored:
+      - credentials
+      - session-state
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Admin API:
+    id: admin-api
+    description: "Admin-only endpoint that must verify JWT signature and admin role claims."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-service-rest
+    tags: ["admin", "app"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: restricted
+    integrity: critical
+    availability: important
+    justification_cia_rating: "A failed role check exposes privileged operations."
+    multi_tenant: true
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - admin-operations
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Verify JWT:
+        target: token-service
+        description: "Admin endpoint verifies JWT signature, expiry, issuer, audience, and admin role claim."
+        protocol: in-process-library-call
+        authentication: token
+        authorization: technical-user
+        tags: ["jwt", "admin"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - jwt-token
+
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted client network."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - browser
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Juice Shop container/runtime boundary for auth components."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - auth-api
+      - token-service
+      - credential-store
+      - admin-api
+    trust_boundaries_nested: []
+
+shared_runtimes:
+
+  Juice Shop Container:
+    id: juice-shop-container
+    description: "Single container runtime for Juice Shop auth components."
+    tags: []
+    technical_assets_running:
+      - auth-api
+      - token-service
+      - credential-store
+      - admin-api
+
+individual_risk_categories: {}
+
+risk_tracking: {}

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,452 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Local Lab Threat Model  
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - tokens-sessions
+      - product-catalog
+    data_assets_stored:
+      - tokens-sessions
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app is only allowed over HTTPS; no plaintext port 3000 exposure."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app over encrypted backend traffic with mutual service authentication."
+        protocol: https
+        authentication: client-certificate
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0)."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTPS POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+      To Persistent Storage:
+        target: persistent-storage
+        description: "Prepared statements / parameterized SQLite queries and sanitized log writes to encrypted host-mounted database storage; no plaintext secrets are written to logs."
+        protocol: sql-access-protocol-encrypted
+        authentication: credentials
+        authorization: technical-user
+        tags: ["storage"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - user-accounts
+          - orders
+          - product-catalog
+          - logs
+        data_assets_received:
+          - user-accounts
+          - orders
+          - product-catalog
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted encrypted database volume for application data and sanitized logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: database
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,97 @@
+# Lab 2: Threat Modeling with Threagile
+
+## Task 1: Baseline Threat Model
+
+### Risk count by severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | **23** |
+
+### Top 5 risks
+
+1. **missing-authentication** — Missing Authentication covering communication link `To App` from `Reverse Proxy` to `Juice Shop Application`; severity Elevated; affecting `juice-shop`.
+2. **unencrypted-communication** — Unencrypted Communication named `Direct to App (no proxy)` between `User Browser` and `Juice Shop Application`, transferring authentication data; severity Elevated; affecting `user-browser`.
+3. **unencrypted-communication** — Unencrypted Communication named `To App` between `Reverse Proxy` and `Juice Shop Application`; severity Elevated; affecting `reverse-proxy`.
+4. **cross-site-scripting** — Cross-Site Scripting risk at `Juice Shop Application`; severity Elevated; affecting `juice-shop`.
+5. **missing-identity-store** — Missing Identity Store in the threat model, referencing `Reverse Proxy`; severity Medium; affecting `reverse-proxy`.
+
+### STRIDE mapping
+
+- Risk 1: **S/E** — Missing backend authentication allows a caller to spoof trusted proxy traffic and potentially reach app functionality without the intended trust proof.
+- Risk 2: **I/S** — Plain HTTP can expose session tokens and let an attacker reuse them to impersonate a user.
+- Risk 3: **I/T** — Plain proxy-to-app traffic can be observed or modified inside the host/container path.
+- Risk 4: **T/E** — XSS tampers with browser-executed content and can escalate into session theft or unauthorized actions.
+- Risk 5: **S/R** — Without a modeled identity store, the architecture cannot clearly prove who authenticated or support a reliable audit trail.
+
+### Trust boundary observation
+
+The `User Browser -> Direct to App (no proxy) -> Juice Shop Application` arrow crosses from the untrusted Internet boundary into the container-hosted application. It is attractive because it carries authentication/session data directly to the app; if that path stays HTTP, an attacker can target token disclosure or tampering before later controls see the request.
+
+## Task 2: Secure Variant & Diff
+
+### Hardening changes made
+
+- Changed direct browser-to-app traffic from `http` to `https`.
+- Changed reverse-proxy-to-app traffic from `http`/unauthenticated to `https` with `client-certificate` authentication and `technical-user` authorization.
+- Kept outbound WebHook traffic on `https` and documented it as an HTTPS POST.
+- Added an explicit app-to-storage database link using `sql-access-protocol-encrypted`.
+- Marked persistent storage as `data-with-symmetric-shared-key` encrypted.
+- Documented prepared statements / parameterized SQLite queries and sanitized log writes to avoid plaintext secrets in logs.
+- Clarified that the browser processes/stores session and product data, which removes model-noise risks about unnecessary transfers.
+
+### Risk count comparison
+
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 2 | -2 |
+| Medium | 14 | 14 | 0 |
+| Low | 5 | 1 | -4 |
+| **Total** | **23** | **17** | **-6** |
+
+### Which rules are GONE in the secure variant?
+
+1. **missing-authentication** — fixed by adding authenticated backend communication from reverse proxy to app (`client-certificate`, `technical-user`).
+2. **unencrypted-communication** — fixed by changing direct and proxy app traffic to HTTPS and using encrypted SQL access for storage.
+3. **unnecessary-data-transfer** — fixed by declaring that the browser actually processes/stores session and catalog data it receives.
+4. **unnecessary-technical-asset** — fixed by the same browser data-asset clarification, so the browser is no longer modeled as an unused asset.
+
+### Which rules are STILL THERE in the secure variant?
+
+1. **cross-site-scripting** — HTTPS and storage encryption do not remove input/output encoding risk in a web application. Juice Shop still accepts user-controlled data and needs contextual output encoding, CSP, and server-side validation.
+2. **sql-nosql-injection** — The secure model documents parameterized queries, but Threagile still flags database access as a risk category because the app talks to a database over a SQL protocol. In practice, this would be tracked as mitigated only after code review/SAST confirms parameterized queries everywhere.
+3. **missing-vault** — Encrypting storage does not create a dedicated secret-management component. JWT keys, database credentials, and integration secrets would still need a vault or equivalent secret store.
+
+### Honesty check
+
+No, the total did not drop by more than 50%; it dropped from 23 to 17 risks, about 26%. These hardening changes are high value because they remove avoidable plaintext and authentication gaps, but the remaining risks are deeper application and platform concerns that require code fixes, WAF/CSRF defenses, secret management, CI/CD modeling, and runtime hardening.
+
+## Bonus Task: Auth Flow Threat Model
+
+### Risk count
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 5 |
+| Medium | 19 |
+| Low | 4 |
+| **Total** | **28** |
+
+### Three auth-specific risks not in the baseline top 5
+
+1. **sql-nosql-injection** — STRIDE: **T/E** — The `Auth API -> Credential Store` query path can be abused to tamper with credential lookup logic or bypass authentication. Mitigation: enforce parameterized queries for every auth lookup and add SAST/DAST tests specifically around login and registration.
+2. **unguarded-access-from-internet** — STRIDE: **D/E** — The focused model shows the Auth API and Admin API reachable directly from the browser without a modeled guarding layer. Mitigation: place a reverse proxy/WAF/API gateway in front, rate-limit auth routes, and require explicit admin authorization checks before privileged operations.
+3. **missing-authentication-second-factor** — STRIDE: **S/E** — JWT-only access to admin routes means stolen credentials or tokens can become enough for privileged access. Mitigation: require MFA or step-up authentication for admin operations and bind admin tokens to short lifetimes.
+
+### Reflection
+
+The focused auth model surfaced feature-level issues that the baseline architecture view diluted, especially database-backed credential lookup, admin JWT usage, and missing 2FA on privileged flows. The baseline is good at showing insecure transport and major architectural gaps; the auth model is better at showing how a valid-looking token can become the center of spoofing and elevation-of-privilege attacks.


### PR DESCRIPTION
# Goal

Deliver Lab 2 threat modeling for OWASP Juice Shop with baseline STRIDE analysis, a hardened Threagile variant, and the bonus auth-flow model.

## Changes

- Added `submissions/lab2.md` with baseline risk counts, top-5 risks, STRIDE mapping, and trust-boundary observation.
- Added `labs/lab2/threagile-model-secure.yaml` with HTTPS, encrypted storage, authenticated backend traffic, encrypted DB access, and prepared-statement notes.
- Added `labs/lab2/threagile-model-auth.yaml` as a focused auth-flow model for login, JWT issuance/verification, session state, and admin endpoints.
- Compared baseline vs secure risk counts and documented fixed/still-present rules.

## Testing

- Generated baseline Threagile report from `labs/lab2/threagile-model.yaml`.
- Generated secure variant report from `labs/lab2/threagile-model-secure.yaml`.
- Generated auth-flow report from `labs/lab2/threagile-model-auth.yaml`.
- Verified `risks.json` counts match the tables in `submissions/lab2.md`.

Note: XLSX export fails in this Threagile container because one generated sheet name exceeds Excel's 31-character limit, so reports were generated with `-generate-risks-excel=false -generate-tags-excel=false`. PDF, JSON, stats, and diagrams generate successfully.

## Artifacts & Screenshots

- Submission: `submissions/lab2.md`
- Secure model: `labs/lab2/threagile-model-secure.yaml`
- Auth-flow model: `labs/lab2/threagile-model-auth.yaml`
- Screenshots or links: regenerated Threagile outputs are local/gitignored under `labs/lab2/output*`

## Checklist

- [x] Title is clear (`feat(lab2): Threagile threat model + secure variant + auth flow`)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab2.md` exists
- [x] Task 1 — Baseline risk table + top-5 with STRIDE mapping
- [x] Task 2 — Secure variant + risk diff table
- [x] Bonus — Auth-flow model + 3 auth-specific risks