### PR TITLE
feat(lab2): Threagile threat model + secure variant + auth flow

### DIFF
--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,423 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop Auth Flow Threat Model
+date: 2026-06-12
+
+author:
+  name: Anastasiia Mikhelson
+  homepage: https://github.com/4rni4ka
+
+management_summary_comment: >
+  Focused model for the Juice Shop authentication flow: browser login, credential
+  lookup, JWT signing, JWT verification, and admin endpoint access.
+
+business_criticality: important
+
+business_overview:
+  description: >
+    This model narrows the architecture to the authentication and authorization
+    path, where spoofing and elevation-of-privilege failures are the most
+    important risks.
+  images: []
+
+technical_overview:
+  description: >
+    A browser sends credentials to the Auth API, which validates them against the
+    credential store and asks the token service to issue a JWT. Later requests
+    include the JWT in the Authorization header. Protected and admin endpoints
+    verify the token and role claims before performing privileged operations.
+  images: []
+
+questions:
+  Are JWT signing keys stored outside the application container?: ""
+  Is MFA required for administrator accounts?: ""
+  Are token verification failures logged and monitored?: ""
+
+abuse_cases:
+  Token Forgery: >
+    An attacker steals or guesses the JWT signing key and creates administrator
+    tokens.
+  Credential Stuffing: >
+    Automated login attempts reuse leaked passwords against the Auth API.
+  Role Claim Tampering: >
+    An attacker modifies JWT claims or abuses weak verification to reach admin
+    endpoints.
+
+security_requirements:
+  Protect JWT signing keys: Store signing keys in a vault or HSM-backed secret store, not in application configuration.
+  Enforce MFA for admin users: Require a second factor before issuing admin-capable sessions.
+  Verify authorization server-side: Validate token signature, expiry, issuer, audience, and admin role on every protected request.
+  Rate limit auth endpoints: Apply rate limiting and lockout on login and registration flows.
+  Audit auth failures: Log failed login, token verification, and admin authorization failures.
+
+tags_available:
+  - auth
+  - jwt
+  - admin
+  - pii
+  - secret
+  - browser
+  - api
+  - datastore
+  - token-service
+
+data_assets:
+
+  Credentials:
+    id: credentials
+    description: "Username and password submitted during login or registration."
+    usage: business
+    tags: ["auth", "pii"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Credential confidentiality and integrity directly control account takeover risk."
+
+  JWT Token:
+    id: jwt-token
+    description: "JWT issued by the Auth API and presented in Authorization headers."
+    usage: business
+    tags: ["auth", "jwt"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: operational
+    justification_cia_rating: "A forged or stolen JWT can impersonate a user or administrator."
+
+  User Session State:
+    id: user-session-state
+    description: "Client-visible authenticated session state derived from the JWT."
+    usage: business
+    tags: ["auth"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: operational
+    justification_cia_rating: "Session state must remain consistent with server-side authorization decisions."
+
+  Admin Operation Requests:
+    id: admin-operation-requests
+    description: "Privileged requests sent to admin-only API routes."
+    usage: business
+    tags: ["admin"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: few
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Tampering with admin operations can change application state and expose sensitive data."
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: "Secret key used to sign and verify JWTs."
+    usage: business
+    tags: ["secret", "jwt"]
+    origin: application
+    owner: Lab Owner
+    quantity: very-few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Key disclosure enables token forgery and privilege escalation."
+
+technical_assets:
+
+  Browser:
+    id: browser
+    description: "User-controlled browser sending login and admin requests."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["browser"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "The browser is attacker-controlled from the server's perspective."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - user-session-state
+      - admin-operation-requests
+    data_assets_stored:
+      - jwt-token
+      - user-session-state
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login and Register:
+        target: auth-api
+        description: "Browser submits credentials to login/register and receives a JWT."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["auth"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+          - user-session-state
+      Protected API Request:
+        target: auth-api
+        description: "Browser calls protected API routes with JWT in the Authorization header."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - user-session-state
+      Admin Request:
+        target: admin-endpoint
+        description: "Browser calls admin endpoint; JWT must contain an admin role claim."
+        protocol: https
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["admin", "jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-operation-requests
+        data_assets_received:
+          - admin-operation-requests
+
+  Auth API:
+    id: auth-api
+    description: "Juice Shop login/register and protected API gateway."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-service-rest
+    tags: ["api", "auth"]
+    internet: false
+    machine: container
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "The Auth API decides whether credentials become sessions."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - user-session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Credential Lookup:
+        target: user-credential-store
+        description: "Parameterized credential lookup against the user database."
+        protocol: sql-access-protocol-encrypted
+        authentication: credentials
+        authorization: technical-user
+        tags: ["auth", "datastore"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - credentials
+      Issue JWT:
+        target: token-service
+        description: "Auth API requests a signed JWT after successful credential validation."
+        protocol: in-process-library-call
+        authentication: none
+        authorization: technical-user
+        tags: ["jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+      Verify JWT for Protected Route:
+        target: token-service
+        description: "Protected routes verify JWT signature, expiry, issuer, and audience."
+        protocol: in-process-library-call
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - user-session-state
+
+  Token Service:
+    id: token-service
+    description: "JWT signing and verification component running inside the Juice Shop container."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: library
+    tags: ["token-service", "jwt"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Compromise of this component allows token forgery or broken verification."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - jwt-signing-key
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  User Credential Store:
+    id: user-credential-store
+    description: "Database table containing user emails and password hashes."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: database
+    tags: ["datastore", "auth", "pii"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Credential store disclosure enables offline password attacks."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - credentials
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Admin Endpoint:
+    id: admin-endpoint
+    description: "Admin-only REST endpoint enforcing JWT role checks."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-service-rest
+    tags: ["admin", "api"]
+    internet: false
+    machine: container
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Admin endpoint controls privileged operations."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - admin-operation-requests
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Verify Admin JWT:
+        target: token-service
+        description: "Admin endpoint verifies JWT signature and admin role before processing."
+        protocol: in-process-library-call
+        authentication: token
+        authorization: enduser-identity-propagation
+        tags: ["admin", "jwt"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - user-session-state
+
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network and user-controlled browser."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - browser
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Juice Shop application container boundary."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - auth-api
+      - token-service
+      - user-credential-store
+      - admin-endpoint
+    trust_boundaries_nested: []
+
+shared_runtimes: {}
+
+individual_risk_categories: {}
+
+risk_tracking: {}

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,449 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Local Lab Threat Model  
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app over HTTPS on 3000 in the hardened variant."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app over HTTPS with a service token on the internal network."
+        protocol: https
+        authentication: token
+        authorization: technical-user
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0)."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTPS POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+      To Persistent Storage:
+        target: persistent-storage
+        description: "Local SQLite database and log I/O via host-mounted volume; SQL access uses prepared statements/parameterized queries and logs are sanitized before encrypted writes."
+        protocol: local-file-access
+        authentication: credentials
+        authorization: technical-user
+        tags: ["storage"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: devops
+        data_assets_sent:
+          - user-accounts
+          - orders
+          - product-catalog
+          - logs
+        data_assets_received:
+          - user-accounts
+          - orders
+          - product-catalog
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Encrypted host-mounted volume for database, file uploads, and sanitized logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: local-file-system
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,120 @@
+# Lab 2 - Submission
+
+## Task 1: Baseline Threat Model
+
+### Run Evidence
+
+- Model: `labs/lab2/threagile-model.yaml`
+- Output directory: `labs/lab2/output/`
+- Generated files: `report.pdf`, `risks.json`, `stats.json`, `technical-assets.json`, `data-asset-diagram.png`, `data-flow-diagram.png`
+- Command used:
+  ```bash
+  docker run --rm -v "$(pwd)/labs/lab2:/app/work" threagile/threagile:0.9.1 \
+    -model /app/work/threagile-model.yaml \
+    -output /app/work/output \
+    -generate-risks-excel=false \
+    -generate-tags-excel=false
+  ```
+- Note: the pinned image reports Threagile `Version: 1.0.0 (20240730113903)` and failed while generating Excel with `the sheet name length exceeds the 31 characters limit`. I disabled Excel output and kept JSON/PDF/diagrams enabled.
+
+### Risk Count By Severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | 23 |
+
+### Top 5 Risks
+
+1. **cross-site-scripting** - Cross-Site Scripting (XSS) risk at Juice Shop Application; severity `elevated`; affecting `juice-shop`.
+2. **missing-authentication** - Missing Authentication covering communication link `To App` from Reverse Proxy to Juice Shop Application; severity `elevated`; affecting `juice-shop`.
+3. **unencrypted-communication** - Unencrypted Communication named `To App` between Reverse Proxy and Juice Shop Application; severity `elevated`; affecting `reverse-proxy`.
+4. **unencrypted-communication** - Unencrypted Communication named `Direct to App (no proxy)` between User Browser and Juice Shop Application transferring authentication data; severity `elevated`; affecting `user-browser`.
+5. **container-baseimage-backdooring** - Container Base Image Backdooring risk at Juice Shop Application; severity `medium`; affecting `juice-shop`.
+
+### STRIDE Mapping
+
+- Risk 1: **T/E** - XSS can tamper with client-side execution and can become elevation of privilege when it steals session tokens or performs actions as another user.
+- Risk 2: **S/E** - Missing authentication on a service-to-service link allows spoofing a trusted component and can lead to unauthorized access to app behavior.
+- Risk 3: **I/T** - Unencrypted proxy-to-app traffic can disclose tokens or request data and allow modification in transit on the internal link.
+- Risk 4: **I/T** - Direct browser-to-app HTTP carrying session/authentication data exposes credentials or JWTs and makes tampering easier across the trust boundary.
+- Risk 5: **T/E** - A backdoored container base image can alter application behavior before runtime and may give an attacker elevated control inside the container.
+
+### Trust Boundary Observation
+
+The `User Browser -> Direct to App (no proxy) -> Juice Shop Application` arrow crosses from the Internet trust boundary into the Container Network and appears in the top-5 unencrypted communication risk. It is attractive because it carries authentication/session data across the least-trusted boundary; if it is not protected with HTTPS, an attacker on the path can observe or alter high-value requests before they reach the app.
+
+## Task 2: Secure Variant & Diff
+
+### Secure Variant Changes
+
+- File: `labs/lab2/threagile-model-secure.yaml`
+- Changed direct browser-to-app traffic from `http` to `https`.
+- Changed reverse-proxy-to-app traffic from `http` to `https`.
+- Added `authentication: token` and `authorization: technical-user` to the reverse-proxy-to-app link.
+- Changed Juice Shop Application encryption from `none` to `transparent`.
+- Changed Persistent Storage from unencrypted `file-server` to encrypted `local-file-system` with `encryption: data-with-symmetric-shared-key`.
+- Added a `To Persistent Storage` local-file-access link documenting prepared statements/parameterized queries and sanitized encrypted log writes.
+- Clarified the outbound WebHook description as `HTTPS POST`; its protocol was already `https` in the baseline model.
+
+### Risk Count Comparison
+
+| Severity | Baseline | Secure | Delta |
+|----------|---------:|-------:|------:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 2 | -2 |
+| Medium | 14 | 12 | -2 |
+| Low | 5 | 4 | -1 |
+| **Total** | 23 | 18 | -5 |
+
+### Which Rules Are Gone In The Secure Variant?
+
+1. `missing-authentication@reverse-proxy>to-app@reverse-proxy@juice-shop` - fixed by adding service-token authentication and `technical-user` authorization to the proxy-to-app link.
+2. `unencrypted-communication@user-browser>direct-to-app-no-proxy@user-browser@juice-shop` - fixed by changing direct app access from `http` to `https`.
+3. `unencrypted-communication@reverse-proxy>to-app@reverse-proxy@juice-shop` - fixed by changing the internal proxy-to-app link from `http` to `https`.
+4. `unencrypted-asset@persistent-storage` - fixed by changing Persistent Storage to `encryption: data-with-symmetric-shared-key`.
+5. `unencrypted-asset@juice-shop` - fixed by changing Juice Shop Application encryption to `transparent`.
+
+### Which Rules Are Still There In The Secure Variant?
+
+1. `cross-site-scripting@juice-shop` still fires because transport encryption and storage encryption do not remove application-layer injection risk. The model still describes Juice Shop as a custom-developed web application accepting JSON/user input, so XSS needs input validation, output encoding, CSP, and review-level mitigations.
+2. `missing-authentication-second-factor@browser>direct-to-app-no-proxy@user-browser@juice-shop` still fires because HTTPS protects transport but does not add MFA. The hardening improved confidentiality and service authentication, but account takeover risk still needs MFA or stronger adaptive authentication.
+
+### Honesty Check
+
+The total did not drop more than 50%; it dropped from 23 to 18, a 5-risk reduction. That says the selected hardening is high-value for transport/storage hygiene, but it does not eliminate core application risks such as XSS, CSRF, MFA gaps, hardening, build infrastructure, and supply-chain controls.
+
+## Bonus Task: Auth Flow Threat Model
+
+### Run Evidence
+
+- Model: `labs/lab2/threagile-model-auth.yaml`
+- Output directory: `labs/lab2/output-auth/`
+- Generated files include `report.pdf`, `risks.json`, `stats.json`, `technical-assets.json`, `data-asset-diagram.png`, and `data-flow-diagram.png`.
+- The model was written from scratch for the auth flow and contains 5 technical assets, 5 data assets, and 7 communication links.
+
+### Risk Count
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 15 |
+| Low | 4 |
+| **Total** | 23 |
+
+### Three Auth-Specific Risks Not In The Baseline Top 5
+
+1. **sql-nosql-injection@auth-api@user-credential-store@auth-api>credential-lookup** - STRIDE: **T/E** - Mitigation: keep credential lookup parameterized, validate input at the Auth API boundary, and test the login query path with SAST/DAST because auth queries are high-impact even when the model says they are parameterized.
+2. **missing-authentication-second-factor@browser>admin-request@browser@admin-endpoint** - STRIDE: **S/E** - Mitigation: require MFA or step-up authentication before issuing or accepting admin-capable JWTs, then enforce the admin role server-side on every admin request.
+3. **missing-vault@token-service** - STRIDE: **S/E** - Mitigation: store JWT signing keys in a vault or HSM-backed secret store, rotate them, and keep verification strict so attackers cannot forge admin tokens after config or image disclosure.
+
+### Reflection
+
+The focused auth model surfaced risks that the architecture model only hinted at: signing-key storage, admin MFA, and the credential lookup path. The baseline model is good for network and deployment boundaries, but the auth model makes feature-level trust decisions visible, especially where JWT claims turn into authorization.


### PR DESCRIPTION
﻿## Goal

This PR delivers Lab 2: baseline Threagile risk analysis, a secure variant with risk diff, and the bonus auth-flow model.

## Changes

- Added `submissions/lab2.md` with baseline risk counts, top-5 risks, STRIDE mapping, secure diff, and auth-flow analysis.
- Added `labs/lab2/threagile-model-secure.yaml` with HTTPS, service-token auth, encrypted storage, and prepared-statement/log-write notes.
- Added `labs/lab2/threagile-model-auth.yaml` as a focused auth/JWT/admin-flow model.

## Testing

- Commands run:
  ```bash
  docker run --rm -v "$(pwd)/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model.yaml -output /app/work/output -generate-risks-excel=false -generate-tags-excel=false
  docker run --rm -v "$(pwd)/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure -generate-risks-excel=false -generate-tags-excel=false
  docker run --rm -v "$(pwd)/labs/lab2:/app/work" threagile/threagile:0.9.1 -model /app/work/threagile-model-auth.yaml -output /app/work/output-auth -generate-risks-excel=false -generate-tags-excel=false
  ```
- Observed output:
  ```text
  Baseline risks: 23
  Secure risks: 18
  Auth-flow risks: 23
  report.pdf and risks.json generated for all three runs
  ```

## Artifacts & Screenshots

- Submission: `submissions/lab2.md`
- Secure variant: `labs/lab2/threagile-model-secure.yaml`
- Auth-flow model: `labs/lab2/threagile-model-auth.yaml`

## Checklist

- [x] Title is clear (`feat(lab2): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab2.md` exists

## Lab Checklist

- [x] Task 1 - Baseline risk table + top-5 with STRIDE mapping
- [x] Task 2 - Secure variant + risk diff table
- [x] Bonus - Auth-flow model + 3 auth-specific risks
