### PR TITLE
feat(lab2): Threagile threat model + secure variant + auth flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Goal
+
+Briefly describe what this PR delivers.
+
+## Changes
+
+- Added:
+- Modified:
+- Updated:
+
+## Testing
+
+Commands executed and observed results:
+
+```
+<paste commands and outputs here>
+```
+
+## Artifacts & Screenshots
+
+- Submission file:
+- Screenshots:
+- Additional artifacts:
+
+## Checklist
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/labs/lab2/threagile-model-auth.yaml
+++ b/labs/lab2/threagile-model-auth.yaml
@@ -1,0 +1,472 @@
+threagile_version: 1.0.0
+
+title: Juice Shop JWT Authentication Threat Model
+date: 2026-06-12
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Focused threat model for the Juice Shop authentication and authorization flow.
+  The model covers login/register, JWT creation, JWT verification, normal protected
+  API access, and admin-only request handling.
+
+business_criticality: critical
+
+business_overview:
+  description: >
+    This model is intentionally small and focused only on authentication-related
+    assets and flows. The goal is to identify spoofing and elevation-of-privilege
+    risks around credentials, JWT tokens, session state, and admin access.
+
+  images: []
+
+technical_overview:
+  description: >
+    A browser submits credentials to the Juice Shop Auth API. The Auth API checks
+    the credential store and asks the JWT component to issue a token. The browser
+    then sends the JWT in the Authorization header when calling protected API
+    endpoints. Protected and admin endpoints verify the JWT before allowing access.
+  images: []
+
+questions:
+  Are JWT signing keys rotated and stored securely?: ""
+  Are admin roles checked server-side on every admin request?: ""
+  Are login and registration endpoints rate-limited?: ""
+  Are tokens excluded from logs and browser-accessible storage?: ""
+
+abuse_cases:
+  Token Forgery: >
+    An attacker attempts to forge or modify a JWT to impersonate another user or gain admin privileges.
+  Credential Stuffing: >
+    An attacker uses leaked usernames and passwords against the login endpoint.
+  Admin Role Bypass: >
+    An authenticated non-admin user attempts to call admin-only endpoints by changing client-side state or token claims.
+  Token Theft: >
+    An attacker steals a JWT from browser storage or network traffic and reuses it.
+
+security_requirements:
+  HTTPS for auth traffic: Login, registration, and protected API calls must use HTTPS.
+  Server-side role checks: Admin authorization must be enforced by the server, not by the browser UI.
+  JWT signing key protection: Signing keys must be treated as sensitive assets and protected from disclosure.
+  Token verification: Every protected request must verify JWT signature, expiration, and role claims.
+  Credential protection: Passwords must be verified against stored hashes and must not be logged.
+
+tags_available:
+  - auth
+  - jwt
+  - token
+  - session
+  - credentials
+  - admin
+  - pii
+  - browser
+  - api
+  - crypto
+  - datastore
+  - protected
+  - role-check
+  - login
+  - register
+
+data_assets:
+
+  Credentials:
+    id: credentials
+    description: "Username and password values submitted during login and registration."
+    usage: business
+    tags: ["credentials", "auth", "pii"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Credentials must remain confidential because disclosure can lead directly
+      to account takeover.
+
+  JWT Token:
+    id: jwt-token
+    description: "JWT issued after successful authentication and later used in the Authorization header."
+    usage: business
+    tags: ["jwt", "token", "auth"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      The JWT represents user identity and roles. If it is stolen or modified,
+      an attacker may impersonate a user or escalate privileges.
+
+  User Session State:
+    id: user-session-state
+    description: "Client and server-side state that represents the currently authenticated user."
+    usage: business
+    tags: ["session", "auth"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Session state connects a user identity to application actions and must not
+      be tampered with or leaked.
+
+  Admin Operation Requests:
+    id: admin-operation-requests
+    description: "Privileged requests that perform administrative actions."
+    usage: business
+    tags: ["admin", "role-check"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: few
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Admin operations can modify sensitive system state and must only be executed
+      by users with a valid admin role.
+
+  JWT Signing Key:
+    id: jwt-signing-key
+    description: "Secret key used to sign and verify JWT tokens."
+    usage: business
+    tags: ["jwt", "crypto", "auth"]
+    origin: application
+    owner: Lab Owner
+    quantity: few
+    confidentiality: strictly-confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      If the signing key is exposed, attackers can create valid tokens and bypass
+      authentication and authorization checks.
+
+technical_assets:
+
+  Browser:
+    id: browser
+    description: "Untrusted end-user browser that submits credentials and stores/uses the JWT."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["browser"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "The browser is controlled by the user and may be controlled by an attacker."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - user-session-state
+    data_assets_stored:
+      - jwt-token
+    data_formats_accepted:
+      - json
+    communication_links:
+      Login and Register:
+        target: auth-api
+        description: "Browser sends login or registration data to the Juice Shop Auth API over HTTPS."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["login", "register"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - jwt-token
+          - user-session-state
+
+      Protected API Call:
+        target: protected-api
+        description: "Browser sends a JWT in the Authorization header to access normal protected API endpoints."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["protected"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received:
+          - user-session-state
+
+      Admin API Call:
+        target: admin-api
+        description: "Browser sends an admin operation request with a JWT that must contain an admin role."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["admin", "role-check"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-operation-requests
+        data_assets_received: []
+
+  Juice Shop Auth API:
+    id: auth-api
+    description: "Login and registration endpoint responsible for validating credentials and starting the JWT issuing flow."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-server
+    tags: ["api", "auth", "login"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "This endpoint is the main entry point for authentication."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - credentials
+      - jwt-token
+      - user-session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Credential Check:
+        target: credential-store
+        description: "Auth API checks submitted credentials against the user credential store."
+        protocol: jdbc
+        authentication: credentials
+        authorization: technical-user
+        tags: ["datastore"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - credentials
+        data_assets_received:
+          - credentials
+
+      Issue JWT:
+        target: jwt-service
+        description: "Auth API requests a signed JWT after successful credential validation."
+        protocol: in-process-library-call
+        authentication: none
+        authorization: technical-user
+        tags: ["jwt", "crypto"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - credentials
+          - user-session-state
+        data_assets_received:
+          - jwt-token
+
+  JWT Signing and Verification:
+    id: jwt-service
+    description: "Component that signs new JWTs and verifies token signature, expiration, and role claims."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-server
+    tags: ["jwt", "crypto"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Compromise of this component can allow token forgery or broken authorization."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - jwt-signing-key
+      - user-session-state
+    data_assets_stored:
+      - jwt-signing-key
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+  Protected API Endpoint:
+    id: protected-api
+    description: "Normal authenticated API endpoint that requires a valid JWT."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-server
+    tags: ["api", "protected"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Processes authenticated non-admin application requests."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - user-session-state
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Verify JWT:
+        target: jwt-service
+        description: "Protected API verifies JWT signature and expiration on every protected request."
+        protocol: in-process-library-call
+        authentication: none
+        authorization: technical-user
+        tags: ["jwt", "protected"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - jwt-token
+        data_assets_received: []
+
+  Admin Endpoint:
+    id: admin-api
+    description: "Admin-only endpoint that requires a valid JWT with an admin role claim."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: web-server
+    tags: ["api", "admin", "role-check"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Admin actions can change sensitive application state and require strict authorization."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - jwt-token
+      - admin-operation-requests
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      Verify Admin JWT:
+        target: jwt-service
+        description: "Admin endpoint verifies token signature and checks that the JWT contains an admin role."
+        protocol: in-process-library-call
+        authentication: none
+        authorization: technical-user
+        tags: ["jwt", "admin", "role-check"]
+        vpn: false
+        ip_filtered: false
+        readonly: true
+        usage: business
+        data_assets_sent:
+          - jwt-token
+          - admin-operation-requests
+        data_assets_received: []
+
+  User Credential Store:
+    id: credential-store
+    description: "Container-local data store containing user password hashes and account authentication data."
+    type: datastore
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: database
+    tags: ["datastore", "credentials"]
+    internet: false
+    machine: container
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: "Credential store is the source of truth for authentication decisions."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - credentials
+      - user-session-state
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted user-controlled network and browser environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - browser
+    trust_boundaries_nested: []
+
+  Container:
+    id: container
+    description: "Container trust boundary for Juice Shop authentication components."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - auth-api
+      - jwt-service
+      - protected-api
+      - admin-api
+      - credential-store
+    trust_boundaries_nested: []
+
+shared_runtimes: {}
+
+individual_risk_categories: {}
+
+risk_tracking: {}

--- a/labs/lab2/threagile-model-secure.yaml
+++ b/labs/lab2/threagile-model-secure.yaml
@@ -1,0 +1,429 @@
+threagile_version: 1.0.0
+
+title: OWASP Juice Shop — Local Lab Threat Model  
+date: 2025-09-18
+
+author:
+  name: Student Name
+  homepage: https://example.edu
+
+management_summary_comment: >
+  Threat model for a local OWASP Juice Shop setup. Users access the app  
+  either directly via HTTP on port 3000 or through an optional reverse proxy that  
+  terminates TLS and adds security headers. The app runs in a container  
+  and writes data to a host-mounted volume (for database, uploads, logs).  
+  Optional outbound notifications (e.g., a challenge-solution WebHook) can be configured for integrations.
+
+business_criticality: important  # archive, operational, important, critical, mission-critical
+
+business_overview:
+  description: >
+    Training environment for DevSecOps. This model covers a deliberately vulnerable  
+    web application (OWASP Juice Shop) running locally in a Docker container. The focus is on a minimal architecture, STRIDE threat analysis, and actionable mitigations for the identified risks.
+
+  images:
+    # - dfd.png: Data Flow Diagram (if exported from the tool)
+
+technical_overview:
+  description: >
+    A user’s web browser connects to the Juice Shop application (Node.js/Express server) either directly on **localhost:3000** (HTTP) or via a **reverse proxy** on ports 80/443 (with HTTPS). The Juice Shop server may issue outbound requests to external services (e.g., a configured **WebHook** for solved challenge notifications). All application data (the SQLite database, file uploads, logs) is stored on the host’s filesystem via a mounted volume. Key trust boundaries include the **Internet** (user & external services) → **Host** (local machine/VM) → **Container Network** (isolated app container).
+  images: []
+
+questions:
+  Do you expose port 3000 beyond localhost?: ""
+  Do you use a reverse proxy with TLS and security headers?: ""
+  Are any outbound integrations (webhooks) configured?: ""
+  Is any sensitive data stored in logs or files?: ""
+
+abuse_cases:
+  Credential Stuffing / Brute Force: >
+    Attackers attempt repeated login attempts to guess credentials or exhaust system resources.
+  Stored XSS via Product Reviews: >
+    Malicious scripts are inserted into product reviews, getting stored and executed in other users’ browsers.
+  SSRF via Outbound Requests: >
+    Server-side requests (e.g. profile image URL fetch or WebHook callback) are abused to access internal network resources.
+
+security_requirements:
+  TLS in transit: Enforce HTTPS for user traffic via a TLS-terminating reverse proxy with strong ciphers and certificate management.
+  AuthZ on sensitive routes: Implement strict server-side authorization checks (role/permission) on admin or sensitive functionalities.
+  Rate limiting & lockouts: Apply rate limiting and account lockout policies to mitigate brute-force and automated attacks on authentication and expensive operations.
+  Secure headers: Add security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, etc.) at the proxy or app to mitigate client-side attacks.
+  Secrets management: Protect secret keys and credentials (JWT signing keys, OAuth client secrets) – keep them out of code repos and avoid logging them.
+
+tags_available:
+  # Relevant technologies and environment tags
+  - docker
+  - nodejs
+  # Data and asset tags
+  - pii
+  - auth
+  - tokens
+  - logs
+  - public
+  - actor
+  - user
+  - optional
+  - proxy
+  - app
+  - storage
+  - volume
+  - saas
+  - webhook
+  # Communication tags
+  - primary
+  - direct
+  - egress
+
+# =========================
+# DATA ASSETS
+# =========================
+data_assets:
+
+  User Accounts:
+    id: user-accounts
+    description: "User profile data, credential hashes, emails."
+    usage: business
+    tags: ["pii", "auth"]
+    origin: user-supplied
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: critical
+    availability: important
+    justification_cia_rating: >
+      Contains personal identifiers and authentication data. High confidentiality is required to protect user privacy, and integrity is critical to prevent account takeovers.
+
+  Orders:
+    id: orders
+    description: "Order history, addresses, and payment metadata (no raw card numbers)."
+    usage: business
+    tags: ["pii"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Contains users’ personal data and business transaction records. Integrity and confidentiality are important to prevent fraud or privacy breaches.
+
+  Product Catalog:
+    id: product-catalog
+    description: "Product information (names, descriptions, prices) available to all users."
+    usage: business
+    tags: ["public"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: public
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Product data is intended to be public, but its integrity is important (to avoid defacement or price manipulation that could mislead users).
+
+  Tokens & Sessions:
+    id: tokens-sessions
+    description: "Session identifiers, JWTs for authenticated sessions, CSRF tokens."
+    usage: business
+    tags: ["auth", "tokens"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: confidential
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      If session tokens are compromised, attackers can hijack user sessions. They must be kept confidential and intact; availability is less critical (tokens can be reissued).
+
+  Logs:
+    id: logs
+    description: "Application and access logs (may inadvertently contain PII or secrets)."
+    usage: devops
+    tags: ["logs"]
+    origin: application
+    owner: Lab Owner
+    quantity: many
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: >
+      Logs are for internal use (troubleshooting, monitoring). They should not be exposed publicly, and sensitive data should be sanitized to protect confidentiality.
+
+# =========================
+# TECHNICAL ASSETS
+# =========================
+technical_assets:
+
+  User Browser:
+    id: user-browser
+    description: "End-user web browser (client)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: true
+    out_of_scope: false
+    justification_out_of_scope:
+    size: system
+    technology: browser
+    tags: ["actor", "user"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: External User
+    confidentiality: public
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "Client controlled by end user (potentially an attacker)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Reverse Proxy (preferred):
+        target: reverse-proxy
+        description: "User browser to reverse proxy (HTTPS on 443)."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["primary"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+      Direct to App (no proxy):
+        target: juice-shop
+        description: "Direct browser access to app over HTTPS on port 3000 for the secure variant."
+        protocol: https
+        authentication: session-id
+        authorization: enduser-identity-propagation
+        tags: ["direct"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Reverse Proxy:
+    id: reverse-proxy
+    description: "Optional reverse proxy (e.g., Nginx) for TLS termination and adding security headers."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: reverse-proxy
+    tags: ["optional", "proxy"]
+    internet: false
+    machine: virtual
+    encryption: transparent
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Not exposed to internet directly; improves security of inbound traffic."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed:
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links:
+      To App:
+        target: juice-shop
+        description: "Proxy forwarding to app over HTTPS internally."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: []
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - tokens-sessions
+        data_assets_received:
+          - product-catalog
+
+  Juice Shop Application:
+    id: juice-shop
+    description: "OWASP Juice Shop server (Node.js/Express, v19.0.0). Uses parameterized queries and prepared statements for database access."
+    type: process
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: application
+    technology: web-server
+    tags: ["app", "nodejs"]
+    internet: false
+    machine: container
+    encryption: none
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "In-scope web application (contains all business logic and vulnerabilities by design)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: true
+    data_assets_processed:
+      - user-accounts
+      - orders
+      - product-catalog
+      - tokens-sessions
+    data_assets_stored:
+      - logs
+    data_formats_accepted:
+      - json
+    communication_links:
+      To Challenge WebHook:
+        target: webhook-endpoint
+        description: "Optional outbound callback (HTTPS POST) to external WebHook when a challenge is solved."
+        protocol: https
+        authentication: none
+        authorization: none
+        tags: ["egress"]
+        vpn: false
+        ip_filtered: false
+        readonly: false
+        usage: business
+        data_assets_sent:
+          - orders
+
+  Persistent Storage:
+    id: persistent-storage
+    description: "Host-mounted volume for database, file uploads, and logs."
+    type: datastore
+    usage: devops
+    used_as_client_by_human: false
+    out_of_scope: false
+    justification_out_of_scope:
+    size: component
+    technology: file-server
+    tags: ["storage", "volume"]
+    internet: false
+    machine: virtual
+    encryption: data-with-symmetric-shared-key
+    owner: Lab Owner
+    confidentiality: internal
+    integrity: important
+    availability: important
+    justification_cia_rating: "Local disk storage for the container – not directly exposed, but if compromised it contains sensitive data (database and logs)."
+    multi_tenant: false
+    redundant: false
+    custom_developed_parts: false
+    data_assets_processed: []
+    data_assets_stored:
+      - logs
+      - user-accounts
+      - orders
+      - product-catalog
+    data_formats_accepted:
+      - file
+    communication_links: {}
+
+  Webhook Endpoint:
+    id: webhook-endpoint
+    description: "External WebHook service (3rd-party, if configured for integrations)."
+    type: external-entity
+    usage: business
+    used_as_client_by_human: false
+    out_of_scope: true
+    justification_out_of_scope: "Third-party service to receive notifications (not under our control)."
+    size: system
+    technology: web-service-rest
+    tags: ["saas", "webhook"]
+    internet: true
+    machine: virtual
+    encryption: none
+    owner: Third-Party
+    confidentiality: internal
+    integrity: operational
+    availability: operational
+    justification_cia_rating: "External service that receives data (like order or challenge info). Treated as a trusted integration point but could be abused if misconfigured."
+    multi_tenant: true
+    redundant: true
+    custom_developed_parts: false
+    data_assets_processed:
+      - orders
+    data_assets_stored: []
+    data_formats_accepted:
+      - json
+    communication_links: {}
+
+# =========================
+# TRUST BOUNDARIES
+# =========================
+trust_boundaries:
+
+  Internet:
+    id: internet
+    description: "Untrusted public network (Internet)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - user-browser
+      - webhook-endpoint
+    trust_boundaries_nested:
+      - host
+
+  Host:
+    id: host
+    description: "Local host machine / VM running the Docker environment."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - reverse-proxy
+      - persistent-storage
+    trust_boundaries_nested:
+      - container-network
+
+  Container Network:
+    id: container-network
+    description: "Docker container network (isolated internal network for containers)."
+    type: network-dedicated-hoster
+    tags: []
+    technical_assets_inside:
+      - juice-shop
+    trust_boundaries_nested: []
+
+# =========================
+# SHARED RUNTIMES
+# =========================
+shared_runtimes:
+
+  Docker Host:
+    id: docker-host
+    description: "Docker Engine and default bridge network on the host."
+    tags: ["docker"]
+    technical_assets_running:
+      - juice-shop
+      # If the reverse proxy is containerized, include it:
+      # - reverse-proxy
+
+# =========================
+# INDIVIDUAL RISK CATEGORIES (optional)
+# =========================
+individual_risk_categories: {}
+
+# =========================
+# RISK TRACKING (optional)
+# =========================
+risk_tracking: {}
+
+# (Optional diagram layout tweaks can be added here)
+#diagram_tweak_edge_layout: spline
+#diagram_tweak_layout_left_to_right: true

--- a/submissions/lab2.md
+++ b/submissions/lab2.md
@@ -1,0 +1,90 @@
+# Lab 2 — Submission
+
+## Task 1: Baseline Threat Model
+
+### Risk count by severity
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 4 |
+| Medium | 14 |
+| Low | 5 |
+| **Total** | 23 |
+
+### Top 5 risks
+
+1. **unencrypted-communication** — Unencrypted communication named `Direct to App (no proxy)` between `User Browser` and `Juice Shop Application`, transferring authentication data such as credentials, tokens, or session IDs; severity **elevated**; affecting `user-browser`.
+2. **unencrypted-communication** — Unencrypted communication named `To App` between `Reverse Proxy` and `Juice Shop Application`; severity **elevated**; affecting `reverse-proxy`.
+3. **cross-site-scripting** — Cross-Site Scripting risk at `Juice Shop Application`; severity **elevated**; affecting `juice-shop`.
+4. **missing-authentication** — Missing authentication covering communication link `To App` from `Reverse Proxy` to `Juice Shop Application`; severity **elevated**; affecting `juice-shop`.
+5. **unnecessary-technical-asset** — Unnecessary technical asset named `Persistent Storage`; severity **low**; affecting `persistent-storage`.
+
+### STRIDE mapping
+
+- Risk 1: **I / S** — The direct browser-to-app link transfers authentication data without encryption, so an attacker on the path could read tokens or session IDs and potentially impersonate a user.
+- Risk 2: **I / T** — The reverse-proxy-to-app link is unencrypted, so traffic inside the host/container boundary could be observed or modified if an attacker gains network-level access.
+- Risk 3: **T / E** — Cross-site scripting allows attacker-controlled script execution in a victim’s browser, which can tamper with page behavior and may lead to privilege misuse or session abuse.
+- Risk 4: **S / E** — Missing authentication on the proxy-to-app communication path weakens identity enforcement and can allow requests to reach application functionality without strong proof of identity.
+- Risk 5: **I / D** — Persistent storage increases the amount of data at rest and creates an additional asset that may leak data or become unavailable if not properly protected.
+
+### Trust boundary observation
+
+Looking at `data-flow-diagram.png`, one trust-boundary-crossing arrow that appears in the top risks is **`Direct to App (no proxy)` from `User Browser` to `Juice Shop Application`**. This arrow crosses from the untrusted Internet/user side toward the containerized application and carries `Tokens & Sessions`, which makes it attractive to an attacker because intercepted or manipulated authentication data could enable session hijacking or request tampering.
+
+## Task 2: Secure Variant & Diff
+
+### Risk count comparison
+
+| Severity | Baseline | Secure | Δ |
+|----------|---------:|-------:|--:|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 0 | 0 |
+| Elevated | 4 | 2 | -2 |
+| Medium | 14 | 13 | -1 |
+| Low | 5 | 5 | 0 |
+| **Total** | 23 | 20 | -3 |
+
+### Which rules are GONE in the secure variant?
+
+1. `unencrypted-communication` — The public/direct `User Browser` → `Juice Shop Application` path no longer appears as an unencrypted communication finding because the secure model changes this link from `http` to `https`.
+2. `unencrypted-communication` — The internal `Reverse Proxy` → `Juice Shop Application` path is also no longer reported as unencrypted because the secure model changes the backend link to `https`.
+3. `unencrypted-asset` — The storage-related at-rest protection finding was reduced by changing `Persistent Storage` from `encryption: none` to `encryption: data-with-symmetric-shared-key`.
+Note: the unique disappeared category list only shows `unencrypted-communication`, because two removed findings share the same category. The overall risk count confirms that three findings were removed: total risks changed from 23 to 20.
+
+### Which rules are STILL THERE in the secure variant?
+
+1. `cross-site-scripting` — This remains because the secure variant changes the architecture and transport/storage protections, but it does not modify the vulnerable application code. Preventing XSS would require application-level controls such as output encoding, input validation, safer templating, and a restrictive Content Security Policy.
+2. `missing-waf` — This remains because the model still does not include a Web Application Firewall or equivalent request-filtering layer in front of the Juice Shop application.
+3. `missing-vault` — This remains because encrypted storage is not the same as dedicated secret management. A proper vault or managed secret store would still be needed for JWT keys, API tokens, credentials, and other sensitive configuration.
+
+### Honesty check
+
+The total number of risks decreased from **23** to **20**, which is a reduction of **3 risks** or about **13.0%**.
+The drop is useful, but it is far below 50%. This means the selected changes mostly fix a narrow part of the model: encrypted communication and encrypted storage. The remaining risks require different types of work, such as authentication design, secret management, WAF/proxy controls, application hardening, and fixing application-layer vulnerabilities like XSS and CSRF.
+
+## Bonus Task: Auth Flow Threat Model
+
+### Risk count
+
+| Severity | Count |
+|----------|------:|
+| Critical | 0 |
+| High | 0 |
+| Elevated | 8 |
+| Medium | 24 |
+| Low | 14 |
+| **Total** | 46 |
+
+### Three auth-specific risks (NOT in the baseline model's top 5)
+
+1. **sql-nosql-injection** — STRIDE: **T / E / I** — Mitigation: Use parameterized queries or prepared statements for all credential lookups. The Auth API should never build database queries by directly concatenating usernames, passwords, or other user-controlled input.
+
+2. **missing-authentication-second-factor** — STRIDE: **S / E** — Mitigation: Require MFA or step-up authentication for admin users and sensitive operations. This reduces the impact of stolen passwords or stolen JWTs because a password alone is not enough to perform privileged actions.
+
+3. **missing-vault** — STRIDE: **I / S / E** — Mitigation: Store JWT signing keys and other authentication secrets in a dedicated vault or managed secret store. Keys should not live directly in application config, source code, container images, or logs.
+
+### Reflection
+
+Building the focused auth model surfaced risks that the broader baseline architecture model did not highlight in its top 5, especially around credential lookup, MFA, JWT signing keys, and admin authorization. The baseline model showed large architectural issues such as unencrypted communication and XSS, while the auth-focused model made the login, token issuance, token verification, and admin-role checks explicit. This shows that feature-level threat models can reveal spoofing and elevation-of-privilege risks that are easy to miss in a higher-level architecture model.


### PR DESCRIPTION
## Goal

Complete Lab 2 by running the baseline Threagile model, creating a secure variant, comparing risk counts, and adding an auth-focused threat model.

## Changes

- Added `submissions/lab2.md`
- Added `labs/lab2/threagile-model-secure.yaml`
- Added `labs/lab2/threagile-model-auth.yaml`

## Testing

Commands executed:

docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 -model /app/work/threagile-model.yaml -output /app/work/output

docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 -model /app/work/threagile-model-secure.yaml -output /app/work/output-secure

docker run --rm -v "$(pwd)/labs/lab2":/app/work threagile/threagile:0.9.1 -model /app/work/threagile-model-auth.yaml -output /app/work/output-auth

Risk counts were compared using `jq` on the generated `risks.json` files.

Note: `risks.json`, `stats.json`, `technical-assets.json`, `data-asset-diagram.png`, and `data-flow-diagram.png` were generated successfully. `report.pdf` and `risks.xlsx` were not produced because Threagile v0.9.1 stopped during spreadsheet/report generation with `the sheet name length exceeds the 31 characters limit`. The submitted analysis is based on `risks.json`.

## Artifacts & Screenshots

- Submission: `submissions/lab2.md`
- Secure variant model: `labs/lab2/threagile-model-secure.yaml`
- Auth-flow model: `labs/lab2/threagile-model-auth.yaml`

## Checklist

- [x] Title is clear (`feat(lab2): Threagile threat model + secure variant + auth flow`)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab2.md` exists
- [x] Task 1 — Baseline risk table + top-5 with STRIDE mapping
- [x] Task 2 — Secure variant + risk diff table
- [x] Bonus Task — Auth-flow model + 3 auth-specific risks
- [x] No generated output folders committed