### PR TITLE
feat(lab3): add pre-commit config and lab submission

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Goal
+Describe in one sentence what this PR delivers.
+
+## Changes
+- Added/updated:
+- Added/updated:
+- Added/updated:
+
+## Testing
+List the commands you ran and the observed results.
+
+```bash
+# paste commands here
+```
+
+Observed output/results:
+- 
+- 
+- 
+
+## Artifacts & Screenshots
+- Submission file: `submissions/labN.md`
+- Other artifacts:
+- Screenshots:
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,40 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Pull Juice Shop image
+        run: docker pull bkimminich/juice-shop:v20.0.0
+
+      - name: Start Juice Shop
+        run: |
+          docker run -d \
+            --name juice-shop \
+            -p 3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for application
+        run: |
+          for i in $(seq 1 30); do
+            curl --silent --fail http://localhost:3000/rest/admin/application-version >/dev/null && exit 0
+            sleep 2
+          done
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          test "$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/)" = "200"
+
+      - name: Show HTTP status code
+        run: |
+          curl -is http://localhost:3000/ | head -n1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -45,7 +45,30 @@ pre-commit installed at .git/hooks/pre-commit
 ### The blocked commit
 Output of the `git commit` that gitleaks blocked:
 ```
-[paste the failing gitleaks hook output here]
+Detect hardcoded secrets.................................................Failed
+- hook id: gitleaks
+- exit code: 1
+
+○
+    │╲
+    │ ○
+    ○ ░
+    ░    gitleaks
+
+Finding:     GH_PAT=REDACTED
+Secret:      REDACTED
+RuleID:      github-pat
+Entropy:     4.143943
+File:        submissions/leak-attempt.txt
+Line:        2
+Fingerprint: submissions/leak-attempt.txt:github-pat:2
+
+11:17PM INF 0 commits scanned.
+11:17PM INF scanned ~101 bytes (101 bytes) in 22.4ms
+11:17PM WRN leaks found: 1
+
+detect private key.......................................................Passed
+check for added large files..............................................Passed
 ```
 
 ### Tune-out exercise

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,0 +1,76 @@
+# Lab 3 - Submission
+
+## Task 1: SSH Commit Signing
+
+### Local configuration
+- `git config --global gpg.format` -> `ssh`
+- `git config --global user.signingkey` -> `/Users/rom.m.ivanov/.ssh/id_ed25519.pub`
+- `git config --global commit.gpgsign` -> `true`
+
+### Local verification
+Output of `git log --show-signature -1`:
+```
+[paste output here - it should include a good SSH signature for your configured email]
+```
+
+### GitHub verification
+- Direct link to your most recent commit on GitHub: [paste commit URL here]
+- Screenshot of the Verified badge: [attach in PR or link here]
+
+### One-paragraph reflection (2-3 sentences)
+In a real team, an unsigned or forged-author commit could let someone deny responsibility for a change or impersonate another developer when introducing malicious code. A visible Verified badge does not prove the code is safe, but it makes authorship tampering much easier to detect and strengthens the audit trail for reviews and incident response.
+
+## Task 2: Pre-commit + gitleaks
+
+### `.pre-commit-config.yaml` (paste the full content)
+```yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+```
+
+### `pre-commit install` output
+```
+pre-commit installed at .git/hooks/pre-commit
+```
+
+### The blocked commit
+Output of the `git commit` that gitleaks blocked:
+```
+[paste the failing gitleaks hook output here]
+```
+
+### Tune-out exercise
+1. **Inline allowlist** - An inline allowlist in `.gitleaks.toml` is acceptable when a specific example value is known, intentional, and tightly scoped, such as a canonical documentation token that is not real and cannot be abused. The advantage is precision: the rule still protects the rest of the repository without suppressing unrelated findings.
+2. **Path exclusion** - Excluding a whole path such as `docs/` is riskier because it creates a blind spot where real secrets can later be committed unnoticed. It may be tempting for noisy documentation folders, but it trades convenience for a broader loss of coverage and should be used very carefully.
+
+## Bonus: History Rewrite
+
+### Before
+```
+[paste output of: git log --oneline before rewrite]
+```
+Output of `git log -p | grep -c 'ghp_'`: **2**
+
+### After
+```
+[paste output of: git log --oneline after rewrite]
+```
+Output of `git log -p | grep -c 'ghp_'`: **0**
+Output of `git log -p | grep -c 'REDACTED'`: **2**
+
+### The two-step pattern in real life
+1. `git filter-repo --replace-text replacements.txt` - rewrite locally
+2. Rotate or revoke the exposed secret and then force-push the rewritten history to the remote. Rewriting history removes the value from Git, but remediation still requires treating the leaked credential as compromised.
+
+### Two real-world gotchas you discovered (2 sentences each)
+1. `git filter-repo` changes commit IDs, so every rewritten commit becomes a different object and any collaborators must resync carefully afterward. In a real shared repository, this makes communication and force-push coordination part of the incident response, not an optional cleanup detail.
+2. Removing the secret from current files is not enough if it still exists in older commits. The exercise shows why prevention with hooks matters: once a secret enters history, cleanup is slower, riskier, and easier to get wrong.

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -56,13 +56,19 @@ Output of the `git commit` that gitleaks blocked:
 
 ### Before
 ```
-[paste output of: git log --oneline before rewrite]
+ba9c76e (HEAD -> main) docs: add usage notes
+0afb204 feat: empty log
+0cde15a feat: add config
+8a8d948 init
 ```
 Output of `git log -p | grep -c 'ghp_'`: **2**
 
 ### After
 ```
-[paste output of: git log --oneline after rewrite]
+5d18498 (HEAD -> main) docs: add usage notes
+4d0f9ed feat: empty log
+0373b55 feat: add config
+eb63517 init
 ```
 Output of `git log -p | grep -c 'ghp_'`: **0**
 Output of `git log -p | grep -c 'REDACTED'`: **2**

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -10,12 +10,17 @@
 ### Local verification
 Output of `git log --show-signature -1`:
 ```
-[paste output here - it should include a good SSH signature for your configured email]
+commit 61b2853e6f42d1b92483dd10cccaabb5834545e6
+Good "git" signature for ro.ivanov@innopolis.university with ED25519 key SHA256:[REDACTED]
+Author: eraegar <romaxim2006@gmail.com>
+Date:   Wed Jun 17 23:45:54 2026 +0300
+
+    feat(lab3): SSH signing, gitleaks hooks, and history rewrite notes
 ```
 
 ### GitHub verification
-- Direct link to your most recent commit on GitHub: [paste commit URL here]
-- Screenshot of the Verified badge: [attach in PR or link here]
+- Direct link to your most recent commit on GitHub: [add after push]
+- Screenshot of the Verified badge: [attach in PR or link after push]
 
 ### One-paragraph reflection (2-3 sentences)
 In a real team, an unsigned or forged-author commit could let someone deny responsibility for a change or impersonate another developer when introducing malicious code. A visible Verified badge does not prove the code is safe, but it makes authorship tampering much easier to detect and strengthens the audit trail for reviews and incident response.


### PR DESCRIPTION

## Goal
Add the Lab 3 submission for SSH commit signing, pre-commit secret scanning with gitleaks, and bonus history-rewrite practice.

## Changes
- Added `submissions/lab3.md` with SSH signing evidence, gitleaks blocked-commit output, tune-out analysis, and bonus history-rewrite results
- Added `.pre-commit-config.yaml` with `gitleaks`, `detect-private-key`, and `check-added-large-files` hooks
- Configured and tested the Lab 3 workflow for signed commits and local pre-commit enforcement

## Testing
Commands used:

```bash
git config --global gpg.format ssh
git config --global user.signingkey ~/.ssh/id_ed25519.pub
git config --global commit.gpgsign true
git config --global tag.gpgsign true

~/Library/Python/3.9/bin/pre-commit install
~/Library/Python/3.9/bin/pre-commit run --files .pre-commit-config.yaml submissions/lab3.md

cat > /tmp/leak-test.txt <<'EOF'
# This is a deliberate fake secret for Lab 3 testing
GH_PAT=ghp_16C7e42F292c6912E7710c838347Ae178B4a
EOF
cp /tmp/leak-test.txt submissions/leak-attempt.txt
git add submissions/leak-attempt.txt
git commit -m "test: should be blocked by gitleaks"

git log --show-signature -1

cd /tmp/lab3-bonus
git log -p | grep -c 'ghp_AAAA'
~/Library/Python/3.9/bin/git-filter-repo --force --replace-text /tmp/replace.txt
git log -p | grep -c 'ghp_AAAA'
git log -p | grep -c 'REDACTED'
```

Observed results:
- SSH commit signing was enabled and local verification showed a good Git SSH signature
- `pre-commit` installed successfully and the configured hooks passed on the Lab 3 files
- `gitleaks` blocked the planted fake GitHub PAT with rule ID `github-pat`
- In the sandbox bonus repo, `git-filter-repo` removed the fake secret from history and replaced it with `REDACTED`
- Secret-count checks changed from `2` before rewrite to `0` after rewrite, while `REDACTED` appeared `2` times

## Artifacts & Screenshots
- Submission file: [submissions/lab3.md](submissions/lab3.md)
- Hook configuration: [.pre-commit-config.yaml](.pre-commit-config.yaml)
- Verified commit evidence: [add commit URL after push]
- Verified badge screenshot: [attach in PR or add link]

- [x] Title is clear (`feat(lab3): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab3.md` exists