### PR TITLE
feat(lab3): SSH signing + gitleaks pre-commit + history rewrite practice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Goal
+ <!-- what this PR delivers (1 sentence) -->
+
+
+---
+
+## Changes 
+ <!-- bullet list of artifacts added/modified -->
+
+
+---
+
+## Testing 
+<!-- how you verified it works (commands + observed output) -->
+
+
+---
+
+## Artifacts & Screenshots 
+<!-- links to files in this PR, image embeds where useful -->
+
+---

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,0 +1,1 @@
+lab3 signing test

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,1 +1,29 @@
-lab3 signing test
+# Lab 3 — Submission
+
+## Task 1: SSH Commit Signing
+
+### Local configuration
+- `git config --global gpg.format` → <ssh>
+- `git config --global user.signingkey` → </home/ratteperk/.ssh/id_ed25519.pub>
+- `git config --global commit.gpgsign` → <true>
+
+### Local verification
+Output of `git log --show-signature -1`:
+```
+commit cdd587014371199c10c11df559a8590b4f4faae2 (HEAD -> feature/lab3, origin/feature/lab3)
+Good "git" signature for spered2109@gmail.com with ED25519 key SHA256:HEqmCG37HkRkR3Q28V4BYUiP2VlfTD4qLvAsChPLckI
+Author: ratteperk <spered2109@gmail.com>
+Date:   Fri Jun 19 02:55:10 2026 +0300
+
+    test: first signed commit
+```
+
+### GitHub verification
+- Direct link to your most recent commit on GitHub: <https://github.com/ratteperk/DevSecOps-Intro/commit/cdd587014371199c10c11df559a8590b4f4faae2>
+- Screenshot of the Verified badge: <img width="1562" height="86" alt="image" src="https://github.com/user-attachments/assets/752734ca-65f0-492d-8de6-aee1bef9dba1" />
+
+### One-paragraph reflection (2-3 sentences)
+What STRIDE-R (Repudiation) scenario would a forged-author commit enable in a real
+team's codebase? How does the Verified badge make that attack visible?
+
+

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -23,7 +23,81 @@ Date:   Fri Jun 19 02:55:10 2026 +0300
 - Screenshot of the Verified badge: <img width="1562" height="86" alt="image" src="https://github.com/user-attachments/assets/752734ca-65f0-492d-8de6-aee1bef9dba1" />
 
 ### One-paragraph reflection (2-3 sentences)
-What STRIDE-R (Repudiation) scenario would a forged-author commit enable in a real
-team's codebase? How does the Verified badge make that attack visible?
+Without signed commits, an attacker can fake user.name and email to push malicious code and later deny doing it (Repudiation). The GitHub "Verified" badge prevents this by cryptographically proving the commit came from the developer's actual SSH key. If a commit lacks the badge, the team instantly knows it's spoofed.
 
 
+## Task 2: Pre-commit + gitleaks
+
+### `.pre-commit-config.yaml`
+```
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+```
+
+### `pre-commit install` output
+```
+pre-commit installed at .git/hooks/pre-commit
+```
+
+### The blocked commit
+Output of the `git commit` that gitleaks blocked (the failing hook output):
+```
+[WARNING] Unstaged files detected.
+[INFO] Stashing unstaged files to /home/ratteperk/.cache/pre-commit/patch1781878314-2223631.
+Detect hardcoded secrets.................................................Failed
+- hook id: gitleaks
+- exit code: 1
+
+○
+    │╲
+    │ ○
+    ○ ░
+    ░    gitleaks
+
+Finding:     GH_PAT=REDACTED
+Secret:      REDACTED
+RuleID:      github-pat
+Entropy:     4.143943
+File:        submissions/leak-attempt.txt
+Line:        2
+Fingerprint: submissions/leak-attempt.txt:github-pat:2
+
+5:11PM INF 1 commits scanned.
+5:11PM INF scan completed in 16.4ms
+5:11PM WRN leaks found: 1
+
+detect private key.......................................................Passed
+check for added large files..............................................Passed
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+[INFO] Restored changes from /home/ratteperk/.cache/pre-commit/patch1781878314-2223631.
+```
+
+### Tune-out exercise
+Suppose a teammate insists they need to commit `AKIA*` strings because they're documentation examples in `docs/`. Briefly describe two approaches:
+1. **Inline allowlist** — `[allowlist]` block in `.gitleaks.toml`. When is this OK?
+
+```
+Add a [allowlist] block in .gitleaks.toml with regexes or paths that match the documentation examples (e.g., AKIAIOSFODNN7EXAMPLE). This is OK when the "secrets" are canonical test values published by AWS/GitHub themselves and will never be rotated. It's risky if the allowlist grows too broad — a real leaked key matching the same pattern could slip through.
+```
+
+2. **Path exclusion** — `paths: [docs/]` in `.gitleaks.toml`. When is this risky?
+
+```
+Add paths: [docs/] in .gitleaks.toml so gitleaks skips the entire docs folder. This is simpler and doesn't require regex tuning, but it's risky because any real secret accidentally dropped into docs/ (e.g., a screenshot with credentials, a config snippet) will bypass scanning entirely. It trades precision for convenience.
+```
+
+(2-3 sentences each. No correct answer; both have tradeoffs.)


### PR DESCRIPTION
## Goal
 <!-- what this PR delivers (1 sentence) -->

Configure SSH commit signing, wire gitleaks into a pre-commit hook, and (bonus) rewrite history to purge a planted secret

---

## Changes 
 <!-- bullet list of artifacts added/modified -->

- .pre-commit-config.yaml - configuration for pre-commits
- submissions/lab3.md - provided solution for the lab

---

## Testing 
<!-- how you verified it works (commands + observed output) -->

1.  Verify the commits are verified :
```
git add <some file>
git commit -m <some commit>
git log --show-signature -1
```

You should see "Good \"git\" signature for <your-email>"

2. verify that pre-commits work
```
git add <some file>
git commit -m <some file>
```

After that you should see checks for correct commit 

## Artifacts & Screenshots 
<!-- links to files in this PR, image embeds where useful -->

---

- [x] Task 1 — SSH signing configured + Verified badge on commit
- [x] Task 2 — .pre-commit-config.yaml + gitleaks demonstrably blocking
- [ ] Bonus — filter-repo rewrite practice documented