### PR TITLE
feat(lab3): secure git setup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Goal
+
+This PR delivers the required lab submission and supporting workflow artifacts.
+
+## Changes
+
+- Added or updated `submissions/labN.md`
+- Added or updated lab-related configuration files
+- Documented testing commands, observed outputs, and screenshots where useful
+
+## Testing
+
+Commands used:
+
+```bash
+<paste commands used for this lab here>
+```
+
+Observed output:
+
+```text
+<paste important output here>
+```
+
+## Artifacts & Screenshots
+
+- Submission file: `submissions/labN.md`
+- Screenshots or evidence: `<add screenshots or links if needed>`
+
+## Checklist
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: detect-private-key
+        exclude: ^labs/lab6/vulnerable-iac/ansible/configure\.yml$
+      - id: check-added-large-files

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -11,7 +11,12 @@
 
 Output of `git log --show-signature -1`:
 
-    WILL_PASTE_AFTER_FINAL_COMMIT
+    commit 445b42369135670e1c54e860934546c2ec25a962 (HEAD -> feature/lab3)
+Good "git" signature for darkdeathinvader@gmail.com with ED25519 key SHA256:[REDACTED]
+Author: Gleb Shvetsov <darkdeathinvader@gmail.com>
+Date:   Fri Jun 19 20:16:12 2026 +0300
+
+    feat(lab3): SSH signing + gitleaks pre-commit + history rewrite practice
 
 ### GitHub verification
 

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -11,12 +11,12 @@
 
 Output of `git log --show-signature -1`:
 
-    commit 445b42369135670e1c54e860934546c2ec25a962 (HEAD -> feature/lab3)
-Good "git" signature for darkdeathinvader@gmail.com with ED25519 key SHA256:[REDACTED]
-Author: Gleb Shvetsov <darkdeathinvader@gmail.com>
-Date:   Fri Jun 19 20:16:12 2026 +0300
+    commit 106953fd0f09d437148fb774199bd81ce913ac17 (HEAD -> feature/lab3)
+    Good "git" signature for darkdeathinvader@gmail.com with ED25519 key SHA256:[REDACTED]
+    Author: Gleb Shvetsov <darkdeathinvader@gmail.com>
+    Date:   Fri Jun 19 20:19:17 2026 +0300
 
-    feat(lab3): SSH signing + gitleaks pre-commit + history rewrite practice
+        docs(lab3): add local signature verification output
 
 ### GitHub verification
 

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -20,8 +20,8 @@ Output of `git log --show-signature -1`:
 
 ### GitHub verification
 
-- Direct link to your most recent commit on GitHub: WILL_PASTE_AFTER_PUSH
-- Screenshot of the Verified badge: WILL_ADD_SCREENSHOT_IN_PR
+- Direct link to a verified commit on GitHub: https://github.com/L10nff/DevSecOps-Intro/commit/0a9ab63122327d9679a16d5de50fabd61bbbd008
+- Screenshot of the Verified badge: attached in PR description
 
 ### One-paragraph reflection
 

--- a/submissions/lab3.md
+++ b/submissions/lab3.md
@@ -1,0 +1,118 @@
+# Lab 3 — Submission
+
+## Task 1: SSH Commit Signing
+
+### Local configuration
+- `git config --global gpg.format` → ssh
+- `git config --global user.signingkey` → /Users/glebshvetsov/.ssh/id_ed25519.pub
+- `git config --global commit.gpgsign` → true
+
+### Local verification
+
+Output of `git log --show-signature -1`:
+
+    WILL_PASTE_AFTER_FINAL_COMMIT
+
+### GitHub verification
+
+- Direct link to your most recent commit on GitHub: WILL_PASTE_AFTER_PUSH
+- Screenshot of the Verified badge: WILL_ADD_SCREENSHOT_IN_PR
+
+### One-paragraph reflection
+
+A forged-author commit could allow an attacker to make malicious code look like it was written by a trusted teammate, which creates a Repudiation problem because the real author can deny responsibility and the team cannot reliably prove who made the change. A Verified badge makes this attack visible because GitHub checks that the commit was signed by a key connected to that developer’s account. If the signature is missing or invalid, the team immediately sees that the commit identity should not be trusted.
+
+
+## Task 2: Pre-commit + gitleaks
+
+### `.pre-commit-config.yaml`
+
+    repos:
+      - repo: https://github.com/gitleaks/gitleaks
+        rev: v8.30.0
+        hooks:
+          - id: gitleaks
+
+      - repo: https://github.com/pre-commit/pre-commit-hooks
+        rev: v6.0.0
+        hooks:
+          - id: detect-private-key
+            exclude: ^labs/lab6/vulnerable-iac/ansible/configure\.yml$
+          - id: check-added-large-files
+
+### `pre-commit install` output
+
+    pre-commit installed at .git/hooks/pre-commit
+
+### `pre-commit run --all-files` output
+
+    Detect hardcoded secrets.................................................Passed
+    detect private key.......................................................Passed
+    check for added large files..............................................Passed
+
+Note: I excluded `labs/lab6/vulnerable-iac/ansible/configure.yml` only for the `detect-private-key` hook because it is an existing vulnerable IaC example from the course repository. Without this narrow exclusion, `pre-commit run --all-files` fails on a file that is unrelated to Lab 3.
+
+### The blocked commit
+
+    Detect hardcoded secrets.................................................Failed
+    - hook id: gitleaks
+    - exit code: 1
+
+    Finding:     GH_PAT=REDACTED
+    Secret:      REDACTED
+    RuleID:      github-pat
+    Entropy:     4.143943
+    File:        submissions/leak-attempt.txt
+    Line:        2
+    Fingerprint: submissions/leak-attempt.txt:github-pat:2
+
+    8:02PM INF 0 commits scanned.
+    8:02PM INF scanned ~101 bytes (101 bytes) in 22.8ms
+    8:02PM WRN leaks found: 1
+
+    detect private key.......................................................Passed
+    check for added large files..............................................Passed
+
+### Tune-out exercise
+
+1. **Inline allowlist**
+
+An inline allowlist in `.gitleaks.toml` is acceptable when the value is clearly fake, intentionally used for documentation or tests, and limited to a very specific pattern. This is safer than disabling scanning for a whole directory because gitleaks still checks the rest of the file and the rest of the repository.
+
+2. **Path exclusion**
+
+A path exclusion such as excluding `docs/` is risky because real secrets can still accidentally appear in documentation files. It may be acceptable only if the directory contains generated or third-party documentation with many known false positives, but it should be reviewed carefully and kept as narrow as possible.
+
+
+## Bonus: History Rewrite
+
+### Before
+
+    77ab3d5 (HEAD -> main) docs: add usage notes
+    f1afc5b feat: empty log
+    6acc5e8 feat: add config
+    3b8b86e init
+
+Output of `git log -p | grep -c 'ghp_'`: **2**
+
+### After
+
+    4405644 (HEAD -> main) docs: add usage notes
+    b770ffb feat: empty log
+    bface22 feat: add config
+    a6df709 init
+
+Output of `git log -p | grep -c 'ghp_'`: **0**
+
+Output of `git log -p | grep -c 'REDACTED'`: **2**
+
+### The two-step pattern in real life
+
+1. `git filter-repo --replace-text replacements.txt` — rewrite locally.
+2. Rotate or revoke the leaked secret immediately. Rewriting Git history only removes the secret from the repository history, but it does not make the already leaked credential safe again.
+
+### Two real-world gotchas you discovered
+
+1. `git filter-repo` refused to run at first because the repository did not look like a fresh clone and showed the error about destructively overwriting history. Since this was only a sandbox repository in `/tmp`, I used `--force`, but in a real project this would require much more care and team coordination.
+
+2. After the rewrite, all commit hashes changed. For example, the latest commit changed from `77ab3d5` to `4405644`, which means a real shared repository would require a force-push and other teammates would need to resynchronize their local clones.


### PR DESCRIPTION
## Goal

This PR delivers Lab 3: Secure Git — Signed Commits, Secret Scanning, and History Hygiene.

## Changes

- Added `submissions/lab3.md`
- Added `.pre-commit-config.yaml`
- Configured pre-commit hooks with `gitleaks`, `detect-private-key`, and `check-added-large-files`
- Documented SSH commit signing evidence, gitleaks blocked-commit output, and bonus `git filter-repo` history rewrite practice
- Added a narrow exclusion for an existing vulnerable Lab 6 file so `pre-commit run --all-files` passes without modifying course files

## Testing

Commands used:

git config --global gpg.format
git config --global user.signingkey
git config --global commit.gpgsign
git log --show-signature -1

pre-commit install
pre-commit run --all-files

git commit -m "test: should be blocked by gitleaks"

git filter-repo --force --replace-text /tmp/replace.txt
git log -p | grep -c 'ghp_AAAA'
git log -p | grep -c 'REDACTED'

Observed output:

Good "git" signature for darkdeathinvader@gmail.com

pre-commit installed at .git/hooks/pre-commit

Detect hardcoded secrets.................................................Passed
detect private key.......................................................Passed
check for added large files..............................................Passed

gitleaks blocked the fake GitHub PAT:
RuleID: github-pat
File: submissions/leak-attempt.txt
Line: 2
leaks found: 1

Bonus history rewrite:
Before: git log -p | grep -c 'ghp_AAAA' -> 2
After:  git log -p | grep -c 'ghp_AAAA' -> 0
After:  git log -p | grep -c 'REDACTED' -> 2

## Artifacts & Screenshots

- Submission file: `submissions/lab3.md`
- Pre-commit config: `.pre-commit-config.yaml`
- Verified badge screenshot: attached below

<img width="1235" height="293" alt="Снимок экрана 2026-06-19 в 20 53 12" src="https://github.com/user-attachments/assets/0d7423e1-c118-40e7-93d7-d0693b00218f" />


## Checklist

- [x] Title is clear (`feat(lab3): secure git setup` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab3.md` exists