### PR TITLE
feat(lab6): Checkov + KICS scans + custom policy

### DIFF
--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,68 @@
+# Lab 6 — Submission
+
+## Task 1: Checkov on Terraform
+
+### Terraform scan
+- Total checks: 127
+- Passed: 49
+- Failed: 78
+
+*Severity not available in JSON without Bridgecrew API key (all null).*
+
+### Top 5 rule IDs (by frequency)
+
+| Rule ID       | Count | What it checks |
+|---------------|------:|----------------|
+| CKV_AWS_355   | 4     | No IAM policy allows "*" resource for restrictable actions |
+| CKV_AWS_289   | 4     | IAM policies must not allow permissions management without constraints |
+| CKV_AWS_382   | 3     | Security groups must not allow egress from 0.0.0.0:0 to port -1 |
+| CKV_AWS_290   | 3     | IAM policies must not allow write access without constraints |
+| CKV_AWS_288   | 3     | IAM policies must not allow data exfiltration |
+
+### Module-leverage analysis
+Fixing the **IAM policy module** (restricting `Resource` to specific ARNs and limiting `Action`) would eliminate CKV_AWS_355, 289, 290, and 288 — **14 findings** (~18% of all failures). Adding a secure default for security group egress (CKV_AWS_382) would cover ~22% of failures from just two module changes.
+
+---
+
+## Task 2: KICS on Ansible + Pulumi
+
+### Ansible
+- Scanned: 3 files, 309 lines
+- Queries: 287
+- Findings: 10
+
+| Severity | Count |
+|----------|------:|
+| HIGH     | 9     |
+| LOW      | 1     |
+
+**Top queries:**
+- Passwords And Secrets - Generic Password (HIGH, 6)
+- Passwords And Secrets - Password in URL (HIGH, 2)
+- Passwords And Secrets - Generic Secret (HIGH, 1)
+- Unpinned Package Version (LOW, 1)
+
+### Pulumi
+- Scanned: 1 file, 280 lines
+- Queries: 21
+- Findings: 6
+
+| Severity | Count |
+|----------|------:|
+| CRITICAL | 1     |
+| HIGH     | 2     |
+| MEDIUM   | 1     |
+| INFO     | 2     |
+
+**Findings:**
+- RDS DB Instance Publicly Accessible (CRITICAL)
+- DynamoDB Table Not Encrypted (HIGH)
+- Generic Password (HIGH)
+- EC2 Instance Monitoring Disabled (MEDIUM)
+- DynamoDB Table Point In Time Recovery Disabled (INFO)
+- EC2 Not EBS Optimized (INFO)
+
+### Checkov vs KICS
+- **Checkov (Terraform):** broader coverage (2,500+ policies), graph-based checks, caught IAM, S3, RDS, security group issues.
+- **KICS (Ansible):** natively parses Ansible playbooks/inventory, found hardcoded secrets and unpinned versions that Checkov would miss.
+- **Unique finding:** KICS detected “DynamoDB Table Not Encrypted” (missing encryption) in Pulumi; Checkov’s Terraform equivalent (CKV_AWS_119) only checks key type (KMS vs. AWS managed), not absence of encryption.


### PR DESCRIPTION
## Goal
Complete Lab 6 — IaC Security: Checkov + KICS (main tasks, no bonus)

## Changes
- Added `submissions/lab6.md` with detailed analysis:
  - **Task 1 – Checkov on Terraform:** 127 total checks, 78 failed; top 5 rule IDs (CKV_AWS_355, 289, 382, 290, 288) and their descriptions
  - Module‑leverage analysis: fixing the IAM policy module alone eliminates 14 findings (~18% of all failures)
  - **Task 2 – KICS on Ansible:** 10 findings (9 HIGH, 1 LOW) – hardcoded passwords in inventory/playbook, secrets in URLs, unpinned package version
  - **Task 2 – KICS on Pulumi:** 6 findings (1 CRITICAL, 2 HIGH, 1 MEDIUM, 2 INFO) – RDS public access, DynamoDB no encryption, monitoring gaps
  - Checkov vs KICS comparison: Checkov better for broad Terraform policy coverage (IAM, S3, RDS, SGs); KICS better for native Ansible/Pulumi parsing and secret detection
- Pulumi state file (`pulumi-state-rendered.json`) missing from repo; Pulumi analysed via KICS only (Task 2), not via Checkov

## Testing & Verification
- Checkov 3.3.2 ran on Terraform directory: `checkov -d labs/lab6/vulnerable-iac/terraform`
- JSON output parsed with `jq`: 127 checks, 78 failed; severity null (no Bridgecrew API key)
- Top 5 rules extracted, module‑leverage impact calculated (14 findings fixed by IAM module change)
- KICS 2.1.20 (Docker) scanned Ansible playbooks: 10 findings – 9 HIGH, 1 LOW; top query “Generic Password” (6 occurrences)
- KICS scanned Pulumi YAML: 6 findings – 1 CRITICAL, 2 HIGH, 1 MEDIUM, 2 INFO
- All `jq` severity and top‑query commands completed successfully

## Artifacts & Screenshots
- `submissions/lab6.md`

## Checklist
- [x] Title is clear
- [x] No secrets committed
- [x] Submission file exists

- [x] Task 1 — Checkov on Terraform with top‑5 rules and module‑leverage analysis
- [x] Task 2 — KICS on Ansible + Pulumi with Checkov‑vs‑KICS comparison
- [ ] Bonus — Custom Checkov policy (skipped)