### PR TITLE
feat(lab7): trivy + PSS restricted

### DIFF
--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop-sa
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: juice-shop
+        image: bkimminich/juice-shop:v20.0.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: logs
+          mountPath: /usr/src/app/logs
+        - name: data
+          mountPath: /usr/src/app/data
+        - name: frontend
+          mountPath: /usr/src/app/frontend/dist
+        - name: i18n
+          mountPath: /usr/src/app/i18n
+        - name: uploads
+          mountPath: /usr/src/app/uploads
+        - name: app-tmp
+          mountPath: /usr/src/app/tmp
+        - name: ftp
+          mountPath: /juice-shop/ftp
+        - name: juice-data
+          mountPath: /juice-shop/data
+        - name: juice-db
+          mountPath: /juice-shop/data/db
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: logs
+        emptyDir: {}
+      - name: data
+        emptyDir: {}
+      - name: frontend
+        emptyDir: {}
+      - name: i18n
+        emptyDir: {}
+      - name: uploads
+        emptyDir: {}
+      - name: app-tmp
+        emptyDir: {}
+      - name: ftp
+        emptyDir: {}
+      - name: juice-data
+        emptyDir: {}
+      - name: juice-db
+        emptyDir: {}

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-deny-all
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 3000
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443

--- a/labs/lab7/k8s/service.yaml
+++ b/labs/lab7/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+spec:
+  selector:
+    app: juice-shop
+  ports:
+  - port: 3000
+    targetPort: 3000
+  type: ClusterIP

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop-sa
+  namespace: juice-shop
+automountServiceAccountToken: false

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,52 @@
+# Lab 7 — Submission
+
+## Task 1: Trivy Image + Config Scan
+
+### Image scan severity breakdown
+| Severity | Total | With fix available |
+|----------|------:|------------------:|
+| Critical | 5 | 5 |
+| High | 43 | 41 |
+| **Total** | 48 | 46 |
+
+### Top 10 CVEs with fixes
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| CVE-2023-46233 | CRITICAL | crypto-js | 3.3.0 | 4.2.0 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.1.0 | 4.2.2 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.4.0 | 4.2.2 |
+| CVE-2019-10744 | CRITICAL | lodash | 2.4.2 | 4.17.12 |
+| CVE-2026-45447 | HIGH | libssl3t64 | 3.5.5-1~deb13u2 | 3.5.6-1~deb13u2 |
+| NSWG-ECO-428 | HIGH | base64url | 0.0.6 | >=3.0.0 |
+| CVE-2020-15084 | HIGH | express-jwt | 0.1.3 | 6.0.0 |
+| CVE-2022-25881 | HIGH | http-cache-semantics | 3.8.1 | 4.1.1 |
+| CVE-2022-23539 | HIGH | jsonwebtoken | 0.1.0 | 9.0.0 |
+| NSWG-ECO-17 | HIGH | jsonwebtoken | 0.1.0 | >=4.2.2 |
+
+### Compared to Lab 4's Grype scan
+Looking back at Lab 4 results:
+1. **CVE-2019-10744 (lodash)** - Both Grype and Trivy found this vulnerability. Both tools detected lodash with the same installed version (2.4.2) and recommended the same fix (4.17.12). This shows good agreement on application-level dependencies.
+
+2. **CVE-2026-45447 (libssl3t64)** - This was found by Trivy but not by Grype. This is because Grype focuses primarily on application-level dependencies (Node.js packages), while Trivy scans both application and OS-level packages. The OS-level vulnerabilities (libssl, glibc) are only detected by Trivy because it scans the full container filesystem including system libraries.
+
+## Task 2: Kubernetes Hardening
+
+### Manifests
+- `namespace.yaml` PSS labels: enforce: restricted, warn: restricted, audit: restricted
+- `serviceaccount.yaml`: dedicated SA with `automountServiceAccountToken: false`
+- `deployment.yaml`: securityContext with runAsNonRoot: true, runAsUser: 1000, fsGroup: 1000, seccompProfile: RuntimeDefault, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities.drop: ["ALL"]
+- `networkpolicy.yaml`: default-deny with ingress (port 3000 from any namespace) and egress (UDP 53 to kube-system, TCP 443 to any)
+
+### Pod is running
+NAME                         READY   STATUS    RESTARTS   AGE
+juice-shop-8849bb897-n7b82   1/1     Running   0          7m
+
+
+### Trivy K8s scan
+| Severity | Count |
+|----------|------:|
+| Critical | 5 |
+| High | 43 |
+
+### What broke and how you fixed it
+`readOnlyRootFilesystem: true` broke Juice Shop because it tries to write to several directories: `/tmp`, `/usr/src/app/logs`, `/usr/src/app/data`, `/juice-shop/ftp`, `/juice-shop/data`, and `/juice-shop/data/db`. I fixed it by adding `emptyDir{}` volume mounts for all these paths, which allows writes while keeping the root filesystem read-only. The SQLite database also required a writable location, so I mounted `/juice-shop/data/db` separately.


### PR DESCRIPTION
# Pull Request

## Goal
Scan Juice Shop image with Trivy (CVE + misconfig + secrets), harden a Kubernetes deployment of it with Pod Security Standards + NetworkPolicy + securityContext

## Changes
- [x] submissions/lab7.md 
- [x] labs/lab7/k8s/ 

## Testing
- Trivy image scan: 48 vulnerabilities (5 CRITICAL, 43 HIGH)
- Fix available: 46 out of 48 (95.8%)
- Kubernetes pod: Running 1/1 with PSS restricted labels
- Trivy k8s scan: 5 CRITICAL, 43 HIGH

## Checklist
- [x] Title is clear (`feat(labN): <topic>`)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/labN.md` exists
- [x] Task 1 — Trivy image + config scans + Grype comparison
- [x] Task 2 — Hardened K8s deployment with PSS restricted + NetworkPolicy
- [ ] Bonus — Conftest policy passing on hardened + failing on bad manifest