### PR TITLE
feat(lab7): trivy + PSS restricted + conftest gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Goal
+
+<!-- 1 sentence: what this PR delivers -->
+
+## Changes
+
+<!-- Bullet list of artifacts added or modified -->
+- 
+
+## Testing
+
+<!-- Commands you ran and the observed output that proves it works -->
+
+## Artifacts & Screenshots
+
+<!-- Links to files in this PR; embed screenshots with ![alt](url) where useful -->
+
+---
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+  description = "Allow documented fake PAT values in lab submission files"
+  paths = [
+    '''submissions/lab3\.md'''
+  ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ["--maxkb=500"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,4 @@ repos:
     hooks:
       - id: detect-private-key
       - id: check-added-large-files
-        args: ["--maxkb=500"]
+        args: ["--maxkb=4096"]

--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: seed-writable-state
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          command:
+            - /nodejs/bin/node
+            - -e
+            - |
+              const fs = require('fs');
+              fs.cpSync('/juice-shop/data', '/work/data', { recursive: true });
+              fs.cpSync('/juice-shop/ftp', '/work/ftp', { recursive: true });
+              fs.cpSync('/juice-shop/frontend/dist/frontend', '/work/frontend', { recursive: true });
+              fs.cpSync('/juice-shop/i18n', '/work/i18n', { recursive: true });
+              fs.cpSync('/juice-shop/.well-known', '/work/well-known', { recursive: true });
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: data
+              mountPath: /work/data
+            - name: ftp
+              mountPath: /work/ftp
+            - name: frontend-dist
+              mountPath: /work/frontend
+            - name: i18n
+              mountPath: /work/i18n
+            - name: well-known
+              mountPath: /work/well-known
+            - name: tmp
+              mountPath: /tmp
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          readinessProbe:
+            httpGet:
+              path: /rest/admin/application-version
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /rest/admin/application-version
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 20
+            timeoutSeconds: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /juice-shop/logs
+            - name: data
+              mountPath: /juice-shop/data
+            - name: ftp
+              mountPath: /juice-shop/ftp
+            - name: uploads
+              mountPath: /juice-shop/uploads
+            - name: frontend-dist
+              mountPath: /juice-shop/frontend/dist/frontend
+            - name: i18n
+              mountPath: /juice-shop/i18n
+            - name: well-known
+              mountPath: /juice-shop/.well-known
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+        - name: ftp
+          emptyDir: {}
+        - name: uploads
+          emptyDir: {}
+        - name: frontend-dist
+          emptyDir: {}
+        - name: i18n
+          emptyDir: {}
+        - name: well-known
+          emptyDir: {}

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-restricted
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: juice-shop
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+automountServiceAccountToken: false

--- a/labs/lab7/policies/pod-hardening.rego
+++ b/labs/lab7/policies/pod-hardening.rego
@@ -1,0 +1,32 @@
+package main
+
+deny contains msg if {
+  input.kind == "Deployment"
+  not input.spec.template.spec.securityContext.runAsNonRoot
+  msg := "deployment must set spec.template.spec.securityContext.runAsNonRoot to true"
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.readOnlyRootFilesystem
+  msg := sprintf("container %q must set readOnlyRootFilesystem to true", [container.name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.allowPrivilegeEscalation == false
+  msg := sprintf("container %q must set allowPrivilegeEscalation to false", [container.name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not drops_all_capabilities(container)
+  msg := sprintf("container %q must drop ALL Linux capabilities", [container.name])
+}
+
+drops_all_capabilities(container) if {
+  container.securityContext.capabilities.drop[_] == "ALL"
+}

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,229 @@
+# Lab 7 - Submission
+
+## Task 1: Trivy Image + Config Scan
+
+Commands used:
+
+```bash
+trivy image bkimminich/juice-shop:v20.0.0 \
+  --severity HIGH,CRITICAL \
+  --format json --output labs/lab7/results/trivy-image.json
+
+trivy image bkimminich/juice-shop:v20.0.0 \
+  --severity HIGH,CRITICAL \
+  --format table | tee labs/lab7/results/trivy-image.txt
+
+trivy config /tmp/Dockerfile \
+  --severity HIGH,CRITICAL \
+  --format table | tee labs/lab7/results/trivy-config.txt
+```
+
+Tool versions:
+
+```text
+Trivy: 0.71.1
+Grype: 0.114.0
+Syft: 1.45.1
+```
+
+Image digest used for the Kubernetes manifest:
+
+```text
+bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+```
+
+### Image scan severity breakdown
+
+| Severity | Total | With fix available |
+|----------|------:|-------------------:|
+| Critical | 5 | 4 |
+| High | 43 | 42 |
+| **Total** | 48 | 46 |
+
+Trivy also reported 2 HIGH secret findings of type `private-key` in the image. I did not paste the secret material into this submission.
+
+### Config scan result
+
+The sample Dockerfile scan reported 1 HIGH misconfiguration:
+
+```text
+DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'
+```
+
+### Top 10 CVEs with fixes
+
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.1.0 | 4.2.2 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.4.0 | 4.2.2 |
+| CVE-2019-10744 | CRITICAL | lodash | 2.4.2 | 4.17.12 |
+| CVE-2023-46233 | CRITICAL | crypto-js | 3.3.0 | 4.2.0 |
+| CVE-2016-1000223 | HIGH | jws | 0.2.6 | >=3.0.0 |
+| CVE-2017-18214 | HIGH | moment | 2.0.0 | 2.19.3 |
+| CVE-2018-16487 | HIGH | lodash | 2.4.2 | >=4.17.11 |
+| CVE-2020-15084 | HIGH | express-jwt | 0.1.3 | 6.0.0 |
+| CVE-2021-23337 | HIGH | lodash | 2.4.2 | 4.17.21 |
+| CVE-2022-23539 | HIGH | jsonwebtoken | 0.1.0 | 9.0.0 |
+
+### Compared to Lab 4's Grype scan
+
+I regenerated a Syft CycloneDX SBOM for `bkimminich/juice-shop:v20.0.0` and scanned it with Grype to compare against the Trivy image scan.
+
+`CVE-2026-45447` was found by both tools on `libssl3t64` version `3.5.5-1~deb13u2`, with fixed version `3.5.6-1~deb13u2`. This is the straightforward overlap case: both scanners matched the Debian package inventory and both databases had a current Debian/OpenSSL advisory for the package.
+
+`CVE-2015-9235` appeared in Trivy for `jsonwebtoken` versions `0.1.0` and `0.4.0`, but Grype reported the same vulnerable package family under GitHub Security Advisory IDs such as `GHSA-c7hr-j4mj-j2w6` instead of that CVE ID. This is a normalization and advisory-source difference, not proof that the vulnerable dependency is absent from Grype. It is exactly why DefectDojo-style deduplication needs more than a raw CVE string: package matching, advisory namespace, and DB freshness can all change the visible ID.
+
+## Task 2: Kubernetes Hardening
+
+### Manifests (paste relevant snippets)
+
+- `namespace.yaml` PSS labels:
+
+```yaml
+pod-security.kubernetes.io/enforce: restricted
+pod-security.kubernetes.io/warn: restricted
+pod-security.kubernetes.io/audit: restricted
+```
+
+- `deployment.yaml` securityContext sections (pod + container):
+
+```yaml
+serviceAccountName: juice-shop
+automountServiceAccountToken: false
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+containers:
+  - name: juice-shop
+    image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+```
+
+- `networkpolicy.yaml` ingress + egress:
+
+```yaml
+policyTypes:
+  - Ingress
+  - Egress
+ingress:
+  - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: juice-shop
+    ports:
+      - protocol: TCP
+        port: 3000
+egress:
+  - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+    ports:
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53
+  - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+    ports:
+      - protocol: TCP
+        port: 443
+```
+
+### Pod is running
+
+Output of `kubectl get pod -n juice-shop -l app=juice-shop`:
+
+```text
+NAME                         READY   STATUS    RESTARTS   AGE
+juice-shop-b94bbb7f7-mkvqx   1/1     Running   0          112s
+```
+
+### Trivy K8s scan
+
+| Severity | Count |
+|----------|------:|
+| Critical | 10 |
+| High | 86 |
+
+Trivy k8s also reported 4 HIGH secret findings. The count is higher than the image scan because the same pinned image is used by both the init container and the main application container.
+
+### What broke and how you fixed it
+
+`readOnlyRootFilesystem: true` initially broke Juice Shop because the application mutates files at startup. It needed writable state for `/tmp`, `/juice-shop/logs`, `/juice-shop/data`, `/juice-shop/ftp`, `/juice-shop/uploads`, `/juice-shop/frontend/dist/frontend`, `/juice-shop/i18n`, and `/juice-shop/.well-known`.
+
+The final Deployment keeps the root filesystem read-only and mounts `emptyDir` volumes only at those write paths. For paths that need seed files (`data`, `ftp`, `frontend/dist/frontend`, `i18n`, and `.well-known`), an initContainer copies the original image contents into the writable volumes before the main container starts.
+
+## Bonus: Conftest Policy
+
+### Policy (paste labs/lab7/policies/pod-hardening.rego)
+
+```rego
+package main
+
+deny contains msg if {
+  input.kind == "Deployment"
+  not input.spec.template.spec.securityContext.runAsNonRoot
+  msg := "deployment must set spec.template.spec.securityContext.runAsNonRoot to true"
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.readOnlyRootFilesystem
+  msg := sprintf("container %q must set readOnlyRootFilesystem to true", [container.name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.allowPrivilegeEscalation == false
+  msg := sprintf("container %q must set allowPrivilegeEscalation to false", [container.name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not drops_all_capabilities(container)
+  msg := sprintf("container %q must drop ALL Linux capabilities", [container.name])
+}
+
+drops_all_capabilities(container) if {
+  container.securityContext.capabilities.drop[_] == "ALL"
+}
+```
+
+### Output: PASS on hardened manifest
+
+```text
+4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
+```
+
+### Output: FAIL on bad manifest
+
+```text
+FAIL - /tmp/bad-pod.yaml - main - container "app" must drop ALL Linux capabilities
+FAIL - /tmp/bad-pod.yaml - main - container "app" must set allowPrivilegeEscalation to false
+FAIL - /tmp/bad-pod.yaml - main - container "app" must set readOnlyRootFilesystem to true
+FAIL - /tmp/bad-pod.yaml - main - deployment must set spec.template.spec.securityContext.runAsNonRoot to true
+
+4 tests, 0 passed, 0 warnings, 4 failures, 0 exceptions
+```
+
+### What this prevents at CI time
+
+This policy catches insecure pod hardening mistakes before `kubectl apply` reaches the cluster: missing non-root execution, writable root filesystems, privilege escalation, and retained Linux capabilities. Admission control is still valuable as the last enforcement point, but CI-time feedback is faster and cheaper because the PR author sees the exact broken manifest before rollout, failed deployments, or production admission rejections.


### PR DESCRIPTION
## Goal

Complete Lab 7 container and Kubernetes security work with Trivy scans, PSS-restricted manifests, NetworkPolicy, and a Conftest policy gate.

## Changes

- Added hardened Kubernetes manifests in `labs/lab7/k8s/`
- Added PSS `restricted` namespace labels, dedicated ServiceAccount, securityContext, resource limits, digest-pinned Juice Shop image, and NetworkPolicy
- Added `labs/lab7/policies/pod-hardening.rego` for the bonus Conftest gate
- Added `submissions/lab7.md` with Trivy image/config results, Grype comparison, Kubernetes hardening evidence, Trivy k8s scan, and Conftest proof

## Testing

- Ran Trivy image scan on `bkimminich/juice-shop:v20.0.0`
  - Critical: 5
  - High: 43
- Ran Trivy config scan on sample Dockerfile
  - Found `DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'`
- Regenerated Syft SBOM and Grype scan for comparison with Trivy
- Created and verified local `kind-lab7` cluster
- Applied Kubernetes manifests and verified pod is running:
  - `juice-shop-b94bbb7f7-mkvqx 1/1 Running`
- Ran Trivy k8s scan for namespace `juice-shop`
  - Critical: 10
  - High: 86
- Ran Conftest on hardened deployment:
  - `4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions`
- Ran Conftest on intentionally bad manifest:
  - `4 tests, 0 passed, 0 warnings, 4 failures, 0 exceptions`
- Ran server-side Kubernetes dry-run:
  - `kubectl apply --dry-run=server -f labs/lab7/k8s/ -o name`
  - Passed
- Ran whitespace validation:
  - `git diff --check -- labs/lab7/k8s labs/lab7/policies submissions/lab7.md`
  - Passed
- Ran secret-pattern scan on PR files
  - No matches

## Artifacts & Screenshots

- `submissions/lab7.md`
- `labs/lab7/k8s/namespace.yaml`
- `labs/lab7/k8s/serviceaccount.yaml`
- `labs/lab7/k8s/deployment.yaml`
- `labs/lab7/k8s/networkpolicy.yaml`
- `labs/lab7/policies/pod-hardening.rego`

---

- [x] Title is clear (`feat(labN): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/labN.md` exists