### PR TITLE
feat(lab7): trivy PSS restricted and conftest gate

### DIFF
--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: seed-writable-data
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /nodejs/bin/node
+            - -e
+            - |
+              const fs = require('fs');
+              fs.cpSync('/juice-shop', '/writable-app', { recursive: true });
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: app
+              mountPath: /writable-app
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          volumeMounts:
+            - name: app
+              mountPath: /juice-shop
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /usr/src/app/logs
+      volumes:
+        - name: app
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-default-deny-with-required-egress
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: juice-shop
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/labs/lab7/k8s/service.yaml
+++ b/labs/lab7/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  type: ClusterIP
+  selector:
+    app: juice-shop
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+automountServiceAccountToken: false

--- a/labs/lab7/policies/pod-hardening.rego
+++ b/labs/lab7/policies/pod-hardening.rego
@@ -1,0 +1,32 @@
+package main
+
+deny contains msg if {
+	input.kind == "Deployment"
+	not input.spec.template.spec.securityContext.runAsNonRoot
+	msg := "deployment must set spec.template.spec.securityContext.runAsNonRoot to true"
+}
+
+deny contains msg if {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	not container.securityContext.readOnlyRootFilesystem
+	msg := sprintf("container %q must set readOnlyRootFilesystem to true", [container.name])
+}
+
+deny contains msg if {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	container.securityContext.allowPrivilegeEscalation != false
+	msg := sprintf("container %q must set allowPrivilegeEscalation to false", [container.name])
+}
+
+deny contains msg if {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	not drops_all_capabilities(container)
+	msg := sprintf("container %q must drop ALL Linux capabilities", [container.name])
+}
+
+drops_all_capabilities(container) if {
+	container.securityContext.capabilities.drop[_] == "ALL"
+}

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,190 @@
+# Lab 7 - Submission
+
+## Task 1: Trivy Image + Config Scan
+
+### Tool versions
+
+```text
+Trivy 0.69.3
+Conftest 0.68.0
+kubectl v1.34.1 client
+k3d v5.9.0 with rancher/k3s:v1.33.0-k3s1
+```
+
+### Image scan severity breakdown
+
+| Severity | Total | With fix available |
+|----------|------:|-------------------:|
+| Critical | 5 | 4 |
+| High | 43 | 42 |
+| **Total** | 48 | 46 |
+
+### Top 10 CVEs with fixes
+
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| CVE-2023-46233 | CRITICAL | crypto-js | 3.3.0 | 4.2.0 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.1.0 | 4.2.2 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.4.0 | 4.2.2 |
+| CVE-2019-10744 | CRITICAL | lodash | 2.4.2 | 4.17.12 |
+| NSWG-ECO-428 | HIGH | base64url | 0.0.6 | >=3.0.0 |
+| CVE-2020-15084 | HIGH | express-jwt | 0.1.3 | 6.0.0 |
+| CVE-2022-25881 | HIGH | http-cache-semantics | 3.8.1 | 4.1.1 |
+| CVE-2022-23539 | HIGH | jsonwebtoken | 0.1.0 | 9.0.0 |
+| CVE-2022-23539 | HIGH | jsonwebtoken | 0.4.0 | 9.0.0 |
+| NSWG-ECO-17 | HIGH | jsonwebtoken | 0.1.0 | >=4.2.2 |
+
+### Dockerfile config scan
+
+The sample Dockerfile scan found one high-severity misconfiguration:
+
+```text
+DS-0002 (HIGH): Last USER command in Dockerfile should not be 'root'
+```
+
+### Compared to Lab 4's Grype scan
+
+`CVE-2023-46233` / `GHSA-xwcq-pm8m-c4vf` was found by both tools for `crypto-js@3.3.0`, and both reported the same fixed version, `4.2.0`. This is a straightforward agreement case: both vulnerability databases mapped the package and vulnerable version range the same way.
+
+`CVE-2015-9235` is a good divergence example at the identifier layer: Trivy emitted the CVE for `jsonwebtoken`, while the Lab 4 Grype report showed the matching issue as `GHSA-c7hr-j4mj-j2w6`. That is not necessarily a true miss; it is advisory alias normalization and database presentation. In a real triage queue I would normalize CVE/GHSA aliases before deciding that one scanner uniquely found the issue.
+
+## Task 2: Kubernetes Hardening
+
+### Namespace PSS labels
+
+```yaml
+pod-security.kubernetes.io/enforce: restricted
+pod-security.kubernetes.io/warn: restricted
+pod-security.kubernetes.io/audit: restricted
+```
+
+### Deployment securityContext sections
+
+```yaml
+serviceAccountName: juice-shop
+automountServiceAccountToken: false
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+containers:
+  - name: juice-shop
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+```
+
+### NetworkPolicy ingress + egress
+
+```yaml
+policyTypes:
+  - Ingress
+  - Egress
+ingress:
+  - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: juice-shop
+    ports:
+      - protocol: TCP
+        port: 3000
+egress:
+  - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+    ports:
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53
+  - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+    ports:
+      - protocol: TCP
+        port: 443
+```
+
+### Pod is running
+
+```text
+NAME                          READY   STATUS    RESTARTS   AGE
+juice-shop-857795c66c-qbtwn   1/1     Running   0          56s
+```
+
+### Trivy K8s scan
+
+| Severity | Count |
+|----------|------:|
+| Critical | 10 |
+| High | 90 |
+
+### What broke and how it was fixed
+
+`readOnlyRootFilesystem: true` first broke Juice Shop because the container writes to more than `/tmp`: it restores files into `/juice-shop/ftp`, writes SQLite/data state, updates frontend public assets, and touches `.well-known/csaf/provider-metadata.json`. Mounting only `/tmp` and logs was not enough. The final manifest uses an initContainer to copy `/juice-shop` into an `emptyDir` and mounts that writable copy back at `/juice-shop`, while the container root filesystem remains read-only and PSS restricted controls stay enabled.
+
+## Bonus: Conftest Policy
+
+### Policy
+
+```rego
+package main
+
+deny contains msg if {
+	input.kind == "Deployment"
+	not input.spec.template.spec.securityContext.runAsNonRoot
+	msg := "deployment must set spec.template.spec.securityContext.runAsNonRoot to true"
+}
+
+deny contains msg if {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	not container.securityContext.readOnlyRootFilesystem
+	msg := sprintf("container %q must set readOnlyRootFilesystem to true", [container.name])
+}
+
+deny contains msg if {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	container.securityContext.allowPrivilegeEscalation != false
+	msg := sprintf("container %q must set allowPrivilegeEscalation to false", [container.name])
+}
+
+deny contains msg if {
+	input.kind == "Deployment"
+	container := input.spec.template.spec.containers[_]
+	not drops_all_capabilities(container)
+	msg := sprintf("container %q must drop ALL Linux capabilities", [container.name])
+}
+
+drops_all_capabilities(container) if {
+	container.securityContext.capabilities.drop[_] == "ALL"
+}
+```
+
+### Output: PASS on hardened manifest
+
+```text
+4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
+```
+
+### Output: FAIL on bad manifest
+
+```text
+FAIL - /tmp/bad-pod-lab7.yaml - main - container "app" must drop ALL Linux capabilities
+FAIL - /tmp/bad-pod-lab7.yaml - main - container "app" must set readOnlyRootFilesystem to true
+FAIL - /tmp/bad-pod-lab7.yaml - main - deployment must set spec.template.spec.securityContext.runAsNonRoot to true
+
+4 tests, 1 passed, 0 warnings, 3 failures, 0 exceptions
+```
+
+### What this prevents at CI time
+
+The policy catches insecure pod specs before `kubectl apply` or admission control sees them: missing non-root execution, writable root filesystems, privilege escalation, and undeclared capability drops. CI-time failure is cheaper than admission-time rejection because the developer gets feedback in the PR, before a release job or deployment pipeline starts touching a cluster.


### PR DESCRIPTION
## Summary
Completed Lab 7 Container Security work with Trivy, Pod Security Standards, Kubernetes hardening, and a Conftest policy gate.

## What changed
- Added hardened Kubernetes manifests for Juice Shop under `labs/lab7/k8s/`.
- Configured PSS `restricted` labels on the namespace.
- Added a dedicated ServiceAccount with token automount disabled.
- Added a digest-pinned Juice Shop Deployment with non-root execution, seccomp, dropped capabilities, read-only root filesystem, resource requests/limits, and writable `emptyDir` mounts.
- Added a NetworkPolicy with restricted ingress and DNS/HTTPS egress.
- Added a Conftest/Rego policy under `labs/lab7/policies/`.
- Added `submissions/lab7.md` with Trivy, K8s, and Conftest evidence.

## Validation
- Trivy image scan completed.
- Trivy K8s scan completed against `k3d-lab7`.
- Juice Shop pod reached `Running 1/1`.
- Conftest passed on the hardened deployment.
- Conftest failed on an intentionally bad manifest with expected deny messages.

## Checklist
- [x] Task 1 - Trivy image + config scans + Grype comparison
- [x] Task 2 - Hardened K8s deployment with PSS restricted + NetworkPolicy
- [x] Bonus - Conftest policy passing on hardened and failing on bad manifest