### PR TITLE
feat(lab7): trivy + PSS restricted + conftest gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+# Goal
+
+Describe in one sentence what this pull request delivers.
+
+# Changes
+
+* List the files added or modified.
+* Briefly describe each change.
+* Mention any important implementation details.
+
+# Testing
+
+Describe how you verified the changes.
+
+Example:
+
+```bash
+docker ps --filter name=juice-shop
+curl -I http://127.0.0.1:3000
+curl -s http://127.0.0.1:3000/api/Products | head -c 200
+```
+
+Observed output:
+
+* Container is running.
+* HTTP status code is 200.
+* Products API returns valid JSON.
+
+# Artifacts & Screenshots
+
+Include links to files in this PR and screenshots where appropriate.
+
+Examples:
+
+* `submissions/lab1.md`
+* Screenshot of the Score Board challenge
+* Screenshot of browser Developer Tools
+
+---
+
+## Checklist
+
+* [ ] Title is clear (`feat(labN): <topic>`)
+* [ ] No secrets/large temp files committed
+* [ ] Submission file at `submissions/labN.md` exists

--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: copy-app
+          image: bkimminich/juice-shop:v20.0.0
+          command:
+            - /nodejs/bin/node
+            - -e
+            - |
+              const fs = require('fs');
+              const path = require('path');
+              function copyDir(src, dest) {
+                if (!fs.existsSync(dest)) fs.mkdirSync(dest, {recursive: true});
+                for (const item of fs.readdirSync(src)) {
+                  const srcPath = path.join(src, item);
+                  const destPath = path.join(dest, item);
+                  if (fs.statSync(srcPath).isDirectory()) copyDir(srcPath, destPath);
+                  else fs.copyFileSync(srcPath, destPath);
+                }
+              }
+              copyDir('/juice-shop', '/app');
+              fs.mkdirSync('/app/logs', {recursive: true});
+              console.log('Init completed');
+          volumeMounts:
+            - name: app
+              mountPath: /app
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop:v20.0.0
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              value: production
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 500m
+            requests:
+              memory: 256Mi
+              cpu: 250m
+          volumeMounts:
+            - name: app
+              mountPath: /juice-shop
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: app
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-netpol
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 3000

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+automountServiceAccountToken: false

--- a/labs/lab7/policies/pod-hardening.rego
+++ b/labs/lab7/policies/pod-hardening.rego
@@ -1,0 +1,53 @@
+package main
+
+deny[msg] {
+  input.kind == "Deployment"
+  pod := input.spec.template.spec
+  not pod.securityContext.runAsNonRoot
+  msg := "Pod must set securityContext.runAsNonRoot: true"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.readOnlyRootFilesystem
+  msg := sprintf("Container '%s' must set securityContext.readOnlyRootFilesystem: true", [container.name])
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  container.securityContext.allowPrivilegeEscalation
+  msg := sprintf("Container '%s' must set securityContext.allowPrivilegeEscalation: false", [container.name])
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.capabilities
+  msg := sprintf("Container '%s' must define securityContext.capabilities", [container.name])
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  container.securityContext.capabilities
+  not has_drop_all(container)
+  msg := sprintf("Container '%s' must drop ALL capabilities", [container.name])
+}
+
+has_drop_all(container) {
+  container.securityContext.capabilities.drop[_] == "ALL"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.template.spec.automountServiceAccountToken == false
+  msg := "Pod must set automountServiceAccountToken: false"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.template.spec.securityContext.seccompProfile
+  msg := "Pod must define seccompProfile in securityContext"
+}

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -101,3 +101,19 @@ Which of these are **MISSING**?
 3. **Permissive Cross-Origin Resource Sharing (CORS)**
    The application returns the header `Access-Control-Allow-Origin: *`, allowing requests from any origin. While acceptable for a deliberately vulnerable training application, such a configuration could expose APIs unnecessarily in a production environment if sensitive resources are available.
    **OWASP Top 10:2025:** A05 – Security Misconfiguration.
+
+## PR Template Setup
+
+* File: `.github/PULL_REQUEST_TEMPLATE.md`
+* Sections included:
+
+  * Goal
+  * Changes
+  * Testing
+  * Artifacts & Screenshots
+* Checklist items:
+
+  * Title is clear (`feat(labN): <topic>`)
+  * No secrets/large temp files committed
+  * Submission file at `submissions/labN.md` exists
+* Auto-fill verified: **[ ] Yes** — Not verified because the assignment was submitted through the university LMS instead of a GitHub Pull Request.

--- a/submissions/lab1.md
+++ b/submissions/lab1.md
@@ -1,0 +1,103 @@
+# Lab 1 — Submission
+
+## Triage Report: OWASP Juice Shop
+
+### Scope & Asset
+
+* Asset: OWASP Juice Shop (local lab instance)
+* Image: `bkimminich/juice-shop:v20.0.0`
+* Image digest: `sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0`
+* Host OS: Arch Linux (rolling), Linux kernel `7.0.12-arch1-1`
+* Docker version: `Docker version 29.6.0, build fb59821d45`
+
+### Deployment Details
+
+* Run command used:
+
+  ```bash
+  docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0
+  ```
+* Access URL: http://127.0.0.1:3000
+* Network exposure: **[x] Yes** (bound only to `127.0.0.1`)
+* Container restart policy: `no`
+
+### Health Check
+
+* HTTP code on `/`: `200`
+
+* API check (first 200 chars of `/api/Products`):
+
+  ```json
+  {"status":"success","data":[{"id":1,"name":"Apple Juice (1000ml)","description":"The all-time classic.","price":1.99,"deluxePrice":0.99,"image":"apple_juice.jpg","createdAt":"2026-06-25T05:37:33.777Z"
+  ```
+
+* Container uptime:
+
+  ```text
+  CONTAINER ID   IMAGE                           COMMAND                  CREATED      STATUS          PORTS                      NAMES
+  cbfabcc3b4f8   bkimminich/juice-shop:v20.0.0   "/nodejs/bin/node /j…"   7 days ago   Up 27 seconds   127.0.0.1:3000->3000/tcp   juice-shop
+  ```
+
+### Initial Surface Snapshot (from browser exploration)
+
+* Login/Registration visible: **[x] Yes** — The Account menu provides login and registration functionality.
+* Product listing/search present: **[x] Yes** — The application displays a searchable product catalog with shopping basket functionality.
+* Admin or account area discoverable: **[x] Yes** — An Account area is visible. During client-side JavaScript inspection, the hidden **Score Board** page was discovered through the route `/score-board`.
+* Client-side errors in DevTools console: **[ ] Yes [x] No** — No client-side errors were observed during the initial exploration.
+* Pre-populated local storage / cookies:
+
+  * Local Storage: empty (`[]`)
+  * Cookies:
+
+    * `cookieconsent_status=dismiss`
+    * `language=en`
+    * `welcomebanner_status=dismiss`
+
+### Security Headers (Quick Look)
+
+Command used:
+
+```bash
+curl -I http://127.0.0.1:3000
+```
+
+Output:
+
+```text
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+Feature-Policy: payment 'self'
+Accept-Ranges: bytes
+Cache-Control: public, max-age=0
+Last-Modified: Thu, 25 Jun 2026 05:37:35 GMT
+ETag: W/"26af-19efd489f10"
+Content-Type: text/html; charset=UTF-8
+Content-Length: 9903
+Vary: Accept-Encoding
+Date: Thu, 25 Jun 2026 05:37:36 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+```
+
+Which of these are **MISSING**?
+
+* [x] `Content-Security-Policy`
+* [x] `Strict-Transport-Security`
+* [ ] `X-Content-Type-Options: nosniff`
+* [ ] `X-Frame-Options`
+
+### Top 3 Risks Observed
+
+1. **Security Through Obscurity (Hidden Route)**
+   The Score Board page was not accessible through the normal user interface, but it was easily discovered by inspecting the client-side JavaScript, where the route `/score-board` was exposed. Hiding functionality on the client side is not an effective security control because anyone can inspect the delivered code.
+   **OWASP Top 10:2025:** A01 – Broken Access Control.
+
+2. **Missing Security Headers**
+   The application response does not include `Content-Security-Policy` or `Strict-Transport-Security`. Missing security headers reduce browser-side protections and may increase the impact of attacks such as Cross-Site Scripting (XSS) or insecure transport.
+   **OWASP Top 10:2025:** A05 – Security Misconfiguration.
+
+3. **Permissive Cross-Origin Resource Sharing (CORS)**
+   The application returns the header `Access-Control-Allow-Origin: *`, allowing requests from any origin. While acceptable for a deliberately vulnerable training application, such a configuration could expose APIs unnecessarily in a production environment if sensitive resources are available.
+   **OWASP Top 10:2025:** A05 – Security Misconfiguration.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,201 @@
+# Lab 7 — Submission
+
+## Task 1: Trivy Image + Config Scan
+
+### Image scan severity breakdown
+| Severity | Total | With fix available |
+|----------|------:|------------------:|
+| Critical | 5 | 5 |
+| High | 43 | 41 |
+| **Total** | **48** | **46** |
+
+### Top 10 CVEs with fixes
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| CVE-2023-46233 | CRITICAL | crypto-js | 3.3.0 | 4.2.0 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.1.0 | 4.2.2 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.4.0 | 4.2.2 |
+| CVE-2019-10744 | CRITICAL | lodash | 2.4.2 | 4.17.12 |
+| CVE-2026-45447 | HIGH | libssl3t64 | 3.5.5-1~deb13u2 | 3.5.6-1~deb13u2 |
+| NSWG-ECO-428 | HIGH | base64url | 0.0.6 | >=3.0.0 |
+| CVE-2020-15084 | HIGH | express-jwt | 0.1.3 | 6.0.0 |
+| CVE-2022-25881 | HIGH | http-cache-semantics | 3.8.1 | 4.1.1 |
+| CVE-2022-23539 | HIGH | jsonwebtoken | 0.1.0 | 9.0.0 |
+| NSWG-ECO-17 | HIGH | jsonwebtoken | 0.1.0 | >=4.2.2 |
+
+### Compared to Lab 4's Grype scan
+
+1. **CVE-2026-45447 (libssl3t64)** — Found by BOTH Grype and Trivy. This is a Debian OpenSSL vulnerability present in the base OS layer. Both tools detect it because they scan the same OS package database (Trivy via its built-in Debian advisory DB, Grype via NVD/GitHub Advisory). Agreement is expected for OS-level CVEs.
+
+2. **CVE-2023-46233 (crypto-js)** — Found by Trivy but NOT by Grype. Trivy's vulnerability database includes npm advisory data that Grype's SBOM-based scan missed. Grype scanned the CycloneDX SBOM from Lab 4, which may have had incomplete package metadata for transitive dependencies. Trivy scans the actual image layers and detects the vulnerable `crypto-js@3.3.0` directly.
+
+---
+
+## Task 2: Kubernetes Hardening
+
+### Manifests
+
+**`namespace.yaml` PSS labels:**
+```yaml
+labels:
+  pod-security.kubernetes.io/enforce: restricted
+  pod-security.kubernetes.io/warn: restricted
+  pod-security.kubernetes.io/audit: restricted
+```
+
+**`deployment.yaml` securityContext sections:**
+```yaml
+# Pod-level
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+```
+
+**`networkpolicy.yaml` ingress + egress:**
+```yaml
+policyTypes:
+  - Ingress
+  - Egress
+ingress:
+  - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+    ports:
+      - protocol: TCP
+        port: 3000
+egress:
+  - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+    ports:
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53
+  - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+    ports:
+      - protocol: TCP
+        port: 443
+      - protocol: TCP
+        port: 3000
+```
+
+### Pod is running
+```
+NAME                          READY   STATUS    RESTARTS   AGE
+juice-shop-674d7dcd5c-h4qsd   1/1     Running   0          30s
+```
+
+### Trivy K8s scan
+| Severity | Vulnerabilities | Misconfigs | Secrets |
+|----------|------:|------:|------:|
+| Critical | 10 | 0 | 0 |
+| High | 86 | 0 | 4 |
+| Medium | 78 | 2 | 4 |
+| Low | 44 | 6 | 0 |
+
+### What broke and how you fixed it
+
+`readOnlyRootFilesystem: true` broke Juice Shop in multiple ways. The app writes to several directories at startup:
+1. `/juice-shop/ftp/` — copies static files for FTP challenges
+2. `/juice-shop/data/` — creates SQLite database
+3. `/juice-shop/logs/` — writes access logs
+4. `/juice-shop/i18n/` — copies localization files
+5. `/juice-shop/frontend/dist/frontend/assets/public/videos/` — restores video files
+
+**Fix:** Used an init container (`copy-app`) with the same Juice Shop image to copy the entire `/juice-shop` directory to an `emptyDir` volume mounted at `/juice-shop`. This makes the application directory writable while keeping the container filesystem read-only. A separate `/tmp` volume handles temporary file writes. The init container uses `/nodejs/bin/node` to run a recursive copy script since the image has no shell (distroless-like).
+
+---
+
+## Bonus: Conftest Policy
+
+### Policy
+```rego
+package main
+
+deny[msg] {
+  input.kind == "Deployment"
+  pod := input.spec.template.spec
+  not pod.securityContext.runAsNonRoot
+  msg := "Pod must set securityContext.runAsNonRoot: true"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.readOnlyRootFilesystem
+  msg := sprintf("Container '%s' must set securityContext.readOnlyRootFilesystem: true", [container.name])
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  container.securityContext.allowPrivilegeEscalation
+  msg := sprintf("Container '%s' must set securityContext.allowPrivilegeEscalation: false", [container.name])
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.capabilities
+  msg := sprintf("Container '%s' must define securityContext.capabilities", [container.name])
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  container.securityContext.capabilities
+  not has_drop_all(container)
+  msg := sprintf("Container '%s' must drop ALL capabilities", [container.name])
+}
+
+has_drop_all(container) {
+  container.securityContext.capabilities.drop[_] == "ALL"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.template.spec.automountServiceAccountToken == false
+  msg := "Pod must set automountServiceAccountToken: false"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.template.spec.securityContext.seccompProfile
+  msg := "Pod must define seccompProfile in securityContext"
+}
+```
+
+### Output: PASS on hardened manifest
+```
+7 tests, 7 passed, 0 warnings, 0 failures, 0 exceptions
+```
+
+### Output: FAIL on bad manifest
+```
+FAIL - main - Container 'app' must define securityContext.capabilities
+FAIL - main - Container 'app' must set securityContext.readOnlyRootFilesystem: true
+FAIL - main - Pod must define seccompProfile in securityContext
+FAIL - main - Pod must set automountServiceAccountToken: false
+FAIL - main - Pod must set securityContext.runAsNonRoot: true
+7 tests, 2 passed, 0 warnings, 5 failures, 0 exceptions
+```
+
+### What this prevents at CI time
+
+This policy catches pods missing critical Pod Security Standards controls **before** `kubectl apply` runs. It enforces the `restricted` profile requirements: non-root execution, read-only filesystem, no privilege escalation, dropped capabilities, no service account token mounting, and seccomp profile. Catching at CI-time is better than admission-time because it provides immediate feedback to developers in the PR workflow, before the code is merged. Admission controllers (like kube-apiserver's Pod Security Admission) can be bypassed in misconfigured clusters or with `--namespace` exceptions, while CI gates are harder to circumvent and catch issues at the earliest possible stage.


### PR DESCRIPTION
# Goal

Scan Juice Shop image with Trivy (CVE + misconfig), harden K8s deployment with Pod Security Standards restricted profile + NetworkPolicy, and write a Conftest/Rego policy gate.

# Changes

* `labs/lab7/k8s/namespace.yaml` — PSS labels (enforce/warn/audit = restricted)
* `labs/lab7/k8s/serviceaccount.yaml` — dedicated SA with automountServiceAccountToken: false
* `labs/lab7/k8s/deployment.yaml` — full hardening: runAsNonRoot, readOnlyRootFilesystem, init container for app copy, emptyDir mounts at /juice-shop and /tmp
* `labs/lab7/k8s/networkpolicy.yaml` — default-deny Ingress/Egress, allow DNS (UDP 53) and HTTPS (TCP 443)
* `labs/lab7/policies/pod-hardening.rego` — 7-rule Rego policy enforcing PSS restricted requirements
* `submissions/lab7.md` — complete submission with scan results, K8s hardening docs, and Conftest output

# Testing

```bash
# Trivy image scan
trivy image bkimminich/juice-shop:v20.0.0 --severity HIGH,CRITICAL --format json --output labs/lab7/results/trivy-image.json

# Conftest on hardened deployment — PASS
conftest test labs/lab7/k8s/deployment.yaml --policy labs/lab7/policies

# Conftest on bad manifest — FAIL
conftest test /tmp/bad-pod.yaml --policy labs/lab7/policies

# K8s deployment
kubectl apply -f labs/lab7/k8s/
kubectl -n juice-shop get pod -l app=juice-shop
# NAME                          READY   STATUS    RESTARTS   AGE
# juice-shop-674d7dcd5c-h4qsd   1/1     Running   0          30s
```

Observed output:

* Trivy image scan: 48 vulnerabilities (5 CRITICAL, 43 HIGH), 46 with fixes
* Conftest hardened: 7 tests, 7 passed, 0 failures
* Conftest bad manifest: 7 tests, 2 passed, 5 failures
* Pod Running 1/1

# Artifacts & Screenshots

* `submissions/lab7.md`
* `labs/lab7/k8s/deployment.yaml`
* `labs/lab7/policies/pod-hardening.rego`
* `labs/lab7/results/trivy-image.json`

---

## Checklist

* [x] Title is clear (`feat(lab7): trivy + PSS restricted + conftest gate`)
* [x] No secrets/large temp files committed
* [x] Submission file at `submissions/lab7.md` exists