### PR TITLE
feat(lab7): trivy + PSS restricted + conftest gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Goal
+Describe in one sentence what this PR delivers.
+
+## Changes
+- Added/updated:
+- Added/updated:
+- Added/updated:
+
+## Testing
+List the commands you ran and the observed results.
+
+```bash
+# paste commands here
+```
+
+Observed output/results:
+- 
+- 
+- 
+
+## Artifacts & Screenshots
+- Submission file: `submissions/labN.md`
+- Other artifacts:
+- Screenshots:
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,40 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Pull Juice Shop image
+        run: docker pull bkimminich/juice-shop:v20.0.0
+
+      - name: Start Juice Shop
+        run: |
+          docker run -d \
+            --name juice-shop \
+            -p 3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for application
+        run: |
+          for i in $(seq 1 30); do
+            curl --silent --fail http://localhost:3000/rest/admin/application-version >/dev/null && exit 0
+            sleep 2
+          done
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          test "$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/)" = "200"
+
+      - name: Show HTTP status code
+        run: |
+          curl -is http://localhost:3000/ | head -n1

--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop-sa
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: init-data
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /nodejs/bin/node
+            - -e
+            - |
+              const fs = require('fs');
+              fs.cpSync('/juice-shop/data', '/writable-data', { recursive: true });
+              fs.cpSync('/juice-shop/frontend/dist/frontend/assets/public/videos', '/writable-videos', { recursive: true });
+              fs.cpSync('/juice-shop/frontend/dist/frontend', '/writable-frontend', { recursive: true });
+              fs.cpSync('/juice-shop/i18n', '/writable-i18n', { recursive: true });
+              fs.cpSync('/juice-shop/.well-known', '/writable-well-known', { recursive: true });
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /writable-data
+            - name: videos
+              mountPath: /writable-videos
+            - name: frontend
+              mountPath: /writable-frontend
+            - name: i18n
+              mountPath: /writable-i18n
+            - name: well-known
+              mountPath: /writable-well-known
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: NODE_ENV
+              value: production
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /juice-shop/logs
+            - name: data
+              mountPath: /juice-shop/data
+            - name: ftp
+              mountPath: /juice-shop/ftp
+            - name: videos
+              mountPath: /juice-shop/frontend/dist/frontend/assets/public/videos
+            - name: frontend
+              mountPath: /juice-shop/frontend/dist/frontend
+            - name: i18n
+              mountPath: /juice-shop/i18n
+            - name: well-known
+              mountPath: /juice-shop/.well-known
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 40
+            periodSeconds: 20
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+        - name: ftp
+          emptyDir: {}
+        - name: videos
+          emptyDir: {}
+        - name: frontend
+          emptyDir: {}
+        - name: i18n
+          emptyDir: {}
+        - name: well-known
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+spec:
+  selector:
+    app: juice-shop
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-restricted
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: juice-shop
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop-sa
+  namespace: juice-shop
+automountServiceAccountToken: false

--- a/labs/lab7/policies/pod-hardening.rego
+++ b/labs/lab7/policies/pod-hardening.rego
@@ -1,0 +1,37 @@
+package main
+
+pod_spec := object.get(object.get(input.spec, "template", {}), "spec", {})
+
+deny contains msg if {
+  input.kind == "Deployment"
+  object.get(object.get(pod_spec, "securityContext", {}), "runAsNonRoot", false) != true
+  msg := "Deployment must set spec.template.spec.securityContext.runAsNonRoot to true"
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  some i
+  container := pod_spec.containers[i]
+  object.get(object.get(container, "securityContext", {}), "readOnlyRootFilesystem", false) != true
+  name := container.name
+  msg := sprintf("Container %q must set readOnlyRootFilesystem to true", [name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  some i
+  container := pod_spec.containers[i]
+  object.get(object.get(container, "securityContext", {}), "allowPrivilegeEscalation", true) != false
+  name := container.name
+  msg := sprintf("Container %q must set allowPrivilegeEscalation to false", [name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  some i
+  container := pod_spec.containers[i]
+  drops := object.get(object.get(object.get(container, "securityContext", {}), "capabilities", {}), "drop", [])
+  not "ALL" in drops
+  name := container.name
+  msg := sprintf("Container %q must drop capability ALL", [name])
+}

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,180 @@
+# Lab 7 — Submission
+
+## Task 1: Trivy Image + Config Scan
+
+### Image scan severity breakdown
+| Severity | Total | With fix available |
+|----------|------:|------------------:|
+| Critical | 5 | 4 |
+| High | 43 | 42 |
+| **Total** | **48** | **46** |
+
+### Top 10 CVEs with fixes
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| `CVE-2026-45447` | High | `libssl3t64` | `3.5.5-1~deb13u2` | `3.5.6-1~deb13u2` |
+| `NSWG-ECO-428` | High | `base64url` | `0.0.6` | `>=3.0.0` |
+| `CVE-2023-46233` | Critical | `crypto-js` | `3.3.0` | `4.2.0` |
+| `CVE-2020-15084` | High | `express-jwt` | `0.1.3` | `6.0.0` |
+| `CVE-2022-25881` | High | `http-cache-semantics` | `3.8.1` | `4.1.1` |
+| `CVE-2015-9235` | Critical | `jsonwebtoken` | `0.1.0` | `4.2.2` |
+| `CVE-2022-23539` | High | `jsonwebtoken` | `0.1.0` | `9.0.0` |
+| `NSWG-ECO-17` | High | `jsonwebtoken` | `0.1.0` | `>=4.2.2` |
+| `CVE-2015-9235` | Critical | `jsonwebtoken` | `0.4.0` | `4.2.2` |
+| `CVE-2022-23539` | High | `jsonwebtoken` | `0.4.0` | `9.0.0` |
+
+### Sample Dockerfile config scan
+I created the intentionally bad sample Dockerfile from the lab instructions and scanned it with Trivy. On this Trivy version, the direct file-path variant did not detect the Dockerfile, so I re-ran it from a directory with the file named `Dockerfile`, which produced one High finding:
+
+| Check | Severity | Meaning |
+|-------|----------|---------|
+| `DS-0002` | High | Last `USER` command in the Dockerfile should not be `root` |
+
+### Compared to Lab 4's Grype scan
+1. One CVE that both tools found: the `jsonwebtoken` issue surfaced in both tools, but under different identifiers. Trivy reported `CVE-2015-9235` for `jsonwebtoken 0.1.0` and `0.4.0`, while Lab 4's Grype results reported the corresponding GitHub advisory `GHSA-c7hr-j4mj-j2w6` for the same package versions. This is a good example of identifier aliasing rather than a substantive disagreement: both tools were effectively pointing at the same vulnerable component.
+2. One issue where the tools diverged: Lab 4's Grype results included `GHSA-35jh-r3h4-6jhm` for `lodash 2.4.2`, while this Trivy image run did not report that exact identifier. The most likely reason is advisory-source normalization and database mapping differences: Grype preserved the GHSA record directly, while Trivy favored a different identifier set and did not emit that exact advisory label in this run.
+
+## Task 2: Kubernetes Hardening
+
+### Manifests (relevant snippets)
+- `namespace.yaml` PSS labels:
+```yaml
+pod-security.kubernetes.io/enforce: restricted
+pod-security.kubernetes.io/warn: restricted
+pod-security.kubernetes.io/audit: restricted
+```
+
+- `deployment.yaml` securityContext sections (pod + container):
+```yaml
+spec:
+  serviceAccountName: juice-shop-sa
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: juice-shop
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+```
+
+- `networkpolicy.yaml` ingress + egress:
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: juice-shop
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+```
+
+### Pod is running
+Output of `kubectl get pod -n juice-shop -l app=juice-shop`:
+```text
+NAME                          READY   STATUS    RESTARTS   AGE
+juice-shop-6c886d8d66-cl8jk   1/1     Running   0          12m
+```
+
+### Trivy K8s scan
+| Severity | Count |
+|----------|------:|
+| Critical | 10 |
+| High | 90 |
+
+The Trivy K8s summary showed the workload itself still carries vulnerable packages and a few high-severity secret detections, but the Kubernetes resource misconfiguration section for the hardened manifests was clean at High/Critical severity.
+
+### What broke and how you fixed it
+`readOnlyRootFilesystem: true` broke Juice Shop in several places because this image mutates content at startup instead of treating its filesystem as immutable. I fixed that by keeping the root filesystem read-only, then adding `emptyDir` mounts for `/tmp`, `/juice-shop/logs`, `/juice-shop/data`, `/juice-shop/ftp`, `/juice-shop/i18n`, `/juice-shop/frontend/dist/frontend`, `/juice-shop/frontend/dist/frontend/assets/public/videos`, and `/juice-shop/.well-known`, plus an `initContainer` that pre-copied the original application data into the writable overlays before the main container started.
+
+## Bonus: Conftest Policy
+
+### Policy
+```rego
+package main
+
+pod_spec := object.get(object.get(input.spec, "template", {}), "spec", {})
+
+deny contains msg if {
+  input.kind == "Deployment"
+  object.get(object.get(pod_spec, "securityContext", {}), "runAsNonRoot", false) != true
+  msg := "Deployment must set spec.template.spec.securityContext.runAsNonRoot to true"
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  some i
+  container := pod_spec.containers[i]
+  object.get(object.get(container, "securityContext", {}), "readOnlyRootFilesystem", false) != true
+  name := container.name
+  msg := sprintf("Container %q must set readOnlyRootFilesystem to true", [name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  some i
+  container := pod_spec.containers[i]
+  object.get(object.get(container, "securityContext", {}), "allowPrivilegeEscalation", true) != false
+  name := container.name
+  msg := sprintf("Container %q must set allowPrivilegeEscalation to false", [name])
+}
+
+deny contains msg if {
+  input.kind == "Deployment"
+  some i
+  container := pod_spec.containers[i]
+  drops := object.get(object.get(object.get(container, "securityContext", {}), "capabilities", {}), "drop", [])
+  not "ALL" in drops
+  name := container.name
+  msg := sprintf("Container %q must drop capability ALL", [name])
+}
+```
+
+### Output: PASS on hardened manifest
+```text
+8 tests, 8 passed, 0 warnings, 0 failures, 0 exceptions
+```
+
+### Output: FAIL on bad manifest
+```text
+FAIL - /tmp/bad-pod.yaml - main - Container "app" must drop capability ALL
+FAIL - /tmp/bad-pod.yaml - main - Container "app" must set allowPrivilegeEscalation to false
+FAIL - /tmp/bad-pod.yaml - main - Container "app" must set readOnlyRootFilesystem to true
+FAIL - /tmp/bad-pod.yaml - main - Deployment must set spec.template.spec.securityContext.runAsNonRoot to true
+
+4 tests, 0 passed, 0 warnings, 4 failures, 0 exceptions
+```
+
+### What this prevents at CI time
+This policy catches pod-hardening regressions before anyone gets to `kubectl apply`, which means insecure manifests can be blocked directly in the developer workflow or CI pipeline. Catching them at CI time is better than waiting for admission-time rejection because it gives faster feedback, keeps bad configs out of deployment reviews entirely, and avoids wasting cluster-side cycles on manifests that never should have been proposed for deployment.


### PR DESCRIPTION
## Goal
Deliver Lab 7 submission with Trivy image/Kubernetes scanning, a hardened Juice Shop Kubernetes deployment aligned to Pod Security Standards restricted, and a Conftest gate for pod hardening.

## Changes
- Added/updated: `submissions/lab7.md` with Trivy image scan analysis, Dockerfile config scan result, Lab 4 Grype comparison, Kubernetes hardening notes, and bonus Conftest evidence
- Added/updated: `labs/lab7/k8s/namespace.yaml`, `labs/lab7/k8s/serviceaccount.yaml`, `labs/lab7/k8s/deployment.yaml`, and `labs/lab7/k8s/networkpolicy.yaml` for the hardened Juice Shop deployment
- Added/updated: `labs/lab7/policies/pod-hardening.rego` to deny deployments missing `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, and `capabilities.drop: ["ALL"]`

## Testing
List the commands you ran and the observed results.

```bash
trivy image bkimminich/juice-shop:v20.0.0 \
  --severity HIGH,CRITICAL \
  --format json --output labs/lab7/results/trivy-image.json

trivy image bkimminich/juice-shop:v20.0.0 \
  --severity HIGH,CRITICAL \
  --format table | tee labs/lab7/results/trivy-image.txt

trivy config /tmp/lab7-docker --severity HIGH,CRITICAL --format table

kubectl apply -f labs/lab7/k8s/namespace.yaml
kubectl apply -f labs/lab7/k8s/serviceaccount.yaml
kubectl apply -f labs/lab7/k8s/deployment.yaml
kubectl apply -f labs/lab7/k8s/networkpolicy.yaml

kubectl -n juice-shop get pod -l app=juice-shop
kubectl -n juice-shop get pod -l app=juice-shop -o yaml > labs/lab7/results/pod-spec.yaml

trivy k8s --include-namespaces juice-shop \
  --severity HIGH,CRITICAL \
  --format json --output labs/lab7/results/trivy-k8s.json

trivy k8s --include-namespaces juice-shop \
  --severity HIGH,CRITICAL \
  --report=summary

conftest test labs/lab7/k8s/deployment.yaml --policy labs/lab7/policies
conftest test /tmp/bad-pod.yaml --policy labs/lab7/policies
```

Observed output/results:
- Trivy image scan found 5 Critical and 43 High vulnerabilities, with fixes available for 46 of 48 total High/Critical findings
- Hardened Juice Shop pod reached `1/1 Running` in namespace `juice-shop`
- Trivy K8s summary reported 10 Critical and 90 High findings on the workload, with no High/Critical Kubernetes misconfiguration findings on the hardened manifests
- Conftest passed on the hardened deployment and failed on the intentionally bad deployment with 4 deny messages

## Artifacts & Screenshots
- Submission file: `submissions/lab7.md`
- Other artifacts: `labs/lab7/k8s/`, `labs/lab7/policies/pod-hardening.rego`
- Screenshots: none

- [x] Title is clear (`feat(lab7): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab7.md` exists