### PR TITLE
feat(lab7): trivy + PSS restricted manifests + conftest gate

### DIFF
--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juice-shop
+  template:
+    metadata:
+      labels:
+        app: juice-shop
+    spec:
+      serviceAccountName: juice-shop
+      automountServiceAccountToken: false
+      # Pod-level securityContext (PSS restricted)
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000                     # makes the emptyDir volumes group-owned by 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+      # readOnlyRootFilesystem: true breaks Juice Shop — at startup it copies files across its
+      # own tree (/juice-shop/ftp, /juice-shop/data (sqlite), /juice-shop/frontend/dist/...,
+      # /juice-shop/.well-known). Instead of enumerating every path, we seed a writable emptyDir
+      # with a copy of the whole /juice-shop dir (owned by uid 1000) and mount it over /juice-shop.
+      # The container root stays read-only; the app writes only inside its own mounted volume.
+      initContainers:
+        - name: seed-app
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          # Node is the only binary in this distroless image — use fs.cpSync to copy the app.
+          command: ["node", "-e", "require('fs').cpSync('/juice-shop','/seed',{recursive:true})"]
+          volumeMounts:
+            - name: app
+              mountPath: /seed
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests: { cpu: "100m", memory: "256Mi" }
+            limits:   { cpu: "500m", memory: "512Mi" }
+
+      containers:
+        - name: juice-shop
+          image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
+          ports:
+            - containerPort: 3000
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests: { cpu: "250m", memory: "512Mi" }
+            limits:   { cpu: "1",    memory: "1Gi" }
+          volumeMounts:
+            - name: app                    # writable copy of the whole app (from initContainer)
+              mountPath: /juice-shop
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet: { path: /, port: 3000 }
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /, port: 3000 }
+            initialDelaySeconds: 60
+            periodSeconds: 20
+
+      volumes:
+        - name: app
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/labs/lab7/k8s/deployment.yaml
+++ b/labs/lab7/k8s/deployment.yaml
@@ -26,18 +26,20 @@ spec:
         seccompProfile:
           type: RuntimeDefault
 
-      # readOnlyRootFilesystem: true breaks Juice Shop — at startup it copies files across its
-      # own tree (/juice-shop/ftp, /juice-shop/data (sqlite), /juice-shop/frontend/dist/...,
-      # /juice-shop/.well-known). Instead of enumerating every path, we seed a writable emptyDir
-      # with a copy of the whole /juice-shop dir (owned by uid 1000) and mount it over /juice-shop.
-      # The container root stays read-only; the app writes only inside its own mounted volume.
+      # readOnlyRootFilesystem: true breaks Juice Shop — at startup it writes across its own tree.
+      # Empirically (via `docker run --read-only`) the writable paths are: /tmp, /juice-shop/ftp,
+      # /juice-shop/logs, /juice-shop/.well-known, .../public/videos, and /juice-shop/data (which
+      # ALSO holds read-only seed files it needs). So all of those get a writable emptyDir; only
+      # /juice-shop/data must retain its baked seeds, so an initContainer copies just that dir
+      # (small — no node_modules) into its emptyDir. node_modules + build stay on the read-only
+      # image layer, so the app's dependency check still sees them.
       initContainers:
-        - name: seed-app
+        - name: seed-data
           image: bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0
-          # Node is the only binary in this distroless image — use fs.cpSync to copy the app.
-          command: ["node", "-e", "require('fs').cpSync('/juice-shop','/seed',{recursive:true})"]
+          # node lives at /nodejs/bin/node (not on PATH) in this distroless image — call it directly.
+          command: ["/nodejs/bin/node", "-e", "require('fs').cpSync('/juice-shop/data','/seed',{recursive:true})"]
           volumeMounts:
-            - name: app
+            - name: data
               mountPath: /seed
           securityContext:
             allowPrivilegeEscalation: false
@@ -46,8 +48,8 @@ spec:
             capabilities:
               drop: ["ALL"]
           resources:
-            requests: { cpu: "100m", memory: "256Mi" }
-            limits:   { cpu: "500m", memory: "512Mi" }
+            requests: { cpu: "100m", memory: "128Mi" }
+            limits:   { cpu: "500m", memory: "256Mi" }
 
       containers:
         - name: juice-shop
@@ -64,21 +66,41 @@ spec:
             requests: { cpu: "250m", memory: "512Mi" }
             limits:   { cpu: "1",    memory: "1Gi" }
           volumeMounts:
-            - name: app                    # writable copy of the whole app (from initContainer)
-              mountPath: /juice-shop
+            - name: data                   # seeded writable copy (static seeds + sqlite DB)
+              mountPath: /juice-shop/data
+            - name: ftp
+              mountPath: /juice-shop/ftp
+            - name: logs
+              mountPath: /juice-shop/logs
+            - name: wellknown
+              mountPath: /juice-shop/.well-known
+            - name: videos
+              mountPath: /juice-shop/frontend/dist/frontend/assets/public/videos
+            - name: i18n
+              mountPath: /juice-shop/i18n
             - name: tmp
               mountPath: /tmp
           readinessProbe:
             httpGet: { path: /, port: 3000 }
-            initialDelaySeconds: 20
+            initialDelaySeconds: 30
             periodSeconds: 10
           livenessProbe:
             httpGet: { path: /, port: 3000 }
-            initialDelaySeconds: 60
+            initialDelaySeconds: 90
             periodSeconds: 20
 
       volumes:
-        - name: app
+        - name: data
+          emptyDir: {}
+        - name: ftp
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: wellknown
+          emptyDir: {}
+        - name: videos
+          emptyDir: {}
+        - name: i18n
           emptyDir: {}
         - name: tmp
           emptyDir: {}

--- a/labs/lab7/k8s/namespace.yaml
+++ b/labs/lab7/k8s/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juice-shop
+  labels:
+    # Pod Security Standards — restricted profile on all three modes (Lecture 7 slide 11)
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest

--- a/labs/lab7/k8s/networkpolicy.yaml
+++ b/labs/lab7/k8s/networkpolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juice-shop-restricted
+  namespace: juice-shop
+spec:
+  podSelector:
+    matchLabels:
+      app: juice-shop
+  policyTypes:
+    - Ingress
+    - Egress
+  # Ingress: default-deny, then explicitly allow HTTP:3000 from the ingress-controller namespace.
+  # (For a `kubectl port-forward` demo, traffic originates from the API server / kubelet and is
+  #  not subject to this policy, so the app stays reachable for the Task 2 proof.)
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+  # Egress: default-deny, then allow only DNS (to kube-system) and outbound HTTPS. Nothing else.
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/labs/lab7/k8s/service.yaml
+++ b/labs/lab7/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+  labels:
+    app: juice-shop
+spec:
+  selector:
+    app: juice-shop
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/labs/lab7/k8s/serviceaccount.yaml
+++ b/labs/lab7/k8s/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: juice-shop
+  namespace: juice-shop
+# Juice Shop never talks to the K8s API — deny it a mounted token by default
+# (Lecture 7 slide 12 anti-pattern). Also re-asserted at pod level in the Deployment.
+automountServiceAccountToken: false

--- a/labs/lab7/policies/pod-hardening.rego
+++ b/labs/lab7/policies/pod-hardening.rego
@@ -1,0 +1,47 @@
+package main
+
+import rego.v1
+
+# Gate Deployments that miss the core container-hardening controls.
+# Run: conftest test labs/lab7/k8s/deployment.yaml --policy labs/lab7/policies
+#
+# The `not <field> == <value>` form (rather than `<field> != <value>`) is deliberate:
+# it also fires when the field is *entirely absent* (undefined), which is exactly the
+# case for a manifest that ships no securityContext at all.
+
+podspec := input.spec.template.spec
+
+# 1. Pod must run as non-root
+deny contains msg if {
+	input.kind == "Deployment"
+	not podspec.securityContext.runAsNonRoot == true
+	msg := "pod securityContext.runAsNonRoot must be true"
+}
+
+# 2. Every container must have a read-only root filesystem
+deny contains msg if {
+	input.kind == "Deployment"
+	some c in podspec.containers
+	not c.securityContext.readOnlyRootFilesystem == true
+	msg := sprintf("container %q: securityContext.readOnlyRootFilesystem must be true", [c.name])
+}
+
+# 3. Every container must forbid privilege escalation
+deny contains msg if {
+	input.kind == "Deployment"
+	some c in podspec.containers
+	not c.securityContext.allowPrivilegeEscalation == false
+	msg := sprintf("container %q: securityContext.allowPrivilegeEscalation must be false", [c.name])
+}
+
+# 4. Every container must drop ALL capabilities
+deny contains msg if {
+	input.kind == "Deployment"
+	some c in podspec.containers
+	not drops_all(c)
+	msg := sprintf("container %q: securityContext.capabilities.drop must include \"ALL\"", [c.name])
+}
+
+drops_all(c) if {
+	"ALL" in c.securityContext.capabilities.drop
+}

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,196 @@
+# Lab 7 — Submission
+
+> Tooling: Trivy 0.71.1, Conftest 0.68.2, kubectl + kind. Image `bkimminich/juice-shop:v20.0.0`.
+
+## Task 1: Trivy Image + Config Scan
+
+### Image scan severity breakdown (`--severity HIGH,CRITICAL`)
+| Severity | Total | With fix available |
+|----------|------:|------------------:|
+| Critical | 5 | 4 |
+| High | 43 | 42 |
+| **Total** | **48** | **46** |
+
+### Top 10 CVEs with fixes
+| CVE | Severity | Package | Installed | Fix |
+|-----|----------|---------|-----------|-----|
+| CVE-2023-46233 | CRITICAL | crypto-js | 3.3.0 | 4.2.0 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.1.0 | 4.2.2 |
+| CVE-2015-9235 | CRITICAL | jsonwebtoken | 0.4.0 | 4.2.2 |
+| CVE-2019-10744 | CRITICAL | lodash | 2.4.2 | 4.17.12 |
+| CVE-2026-45447 | HIGH | libssl3t64 | 3.5.5-1~deb13u2 | 3.5.6-1~deb13u2 |
+| NSWG-ECO-428 | HIGH | base64url | 0.0.6 | >=3.0.0 |
+| CVE-2020-15084 | HIGH | express-jwt | 0.1.3 | 6.0.0 |
+| CVE-2022-25881 | HIGH | http-cache-semantics | 3.8.1 | 4.1.1 |
+| CVE-2022-23539 | HIGH | jsonwebtoken | 0.1.0 | 9.0.0 |
+| NSWG-ECO-17 | HIGH | jsonwebtoken | 0.1.0 | >=4.2.2 |
+
+### Dockerfile config scan (`trivy config`)
+Scanning a deliberately bad Dockerfile (`FROM node:latest`, `USER root`, `EXPOSE 22`, `ADD <url>`):
+| Severity | ID | Finding |
+|----------|-----|---------|
+| HIGH | DS-0002 | Image user should not be 'root' |
+| MEDIUM | DS-0001 | `:latest` tag used |
+| MEDIUM | DS-0004 | Port 22 (SSH) exposed |
+| LOW | DS-0026 | No HEALTHCHECK defined |
+
+### Compared to Lab 4's Grype scan (same image)
+- **Both tools found — CVE-2019-10744 (lodash prototype pollution, Critical).** Trivy reports the
+  CVE id directly; Lab 4's Grype reported the *same* finding under the GitHub advisory alias
+  `GHSA-jf85-cpcp-j695` (whose related CVE is exactly `CVE-2019-10744`). The divergence is only in
+  **identifier namespace** — Grype prefers GHSA for npm, Trivy normalises to CVE — not in coverage.
+- **One tool found, the other missed — CVE-2022-4899 (`libzstd`/zstd, High).** Lab 4's Grype flagged
+  it (fix state `wont-fix`); Trivy reports nothing for zstd. Trivy follows the **Debian Security
+  Tracker**, which marks this not-affected/won't-fix for the distro package and suppresses it; Grype
+  matched against broader **NVD** data (and warned the image distro looked EOL, widening its match).
+  Same class of difference the lecture calls out: different vulnerability DBs + fix-status awareness.
+
+---
+
+## Task 2: Kubernetes Hardening
+
+Four manifests written (`labs/lab7/k8s/`): `namespace.yaml`, `serviceaccount.yaml`,
+`deployment.yaml`, `networkpolicy.yaml` (+ a `service.yaml` for the port-forward proof).
+
+### namespace.yaml — PSS labels (all three modes = restricted)
+```yaml
+pod-security.kubernetes.io/enforce: restricted
+pod-security.kubernetes.io/warn: restricted
+pod-security.kubernetes.io/audit: restricted
+```
+
+### deployment.yaml — securityContext (pod + container)
+```yaml
+# pod-level
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile: { type: RuntimeDefault }
+# container-level (same on initContainer + main container)
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities: { drop: ["ALL"] }
+```
+Image pinned by digest: `bkimminich/juice-shop@sha256:fd58bdc9745416afce8184ee0666278a436574633ea7880365153a63bfd418b0`.
+
+### networkpolicy.yaml — ingress + egress
+```yaml
+policyTypes: [Ingress, Egress]
+ingress:                              # default-deny, then allow :3000 from ingress-controller ns
+  - from: [{ namespaceSelector: { matchLabels: { kubernetes.io/metadata.name: ingress-nginx } } }]
+    ports: [{ protocol: TCP, port: 3000 }]
+egress:                               # allow only DNS (kube-system) + outbound HTTPS
+  - to: [{ namespaceSelector: { matchLabels: { kubernetes.io/metadata.name: kube-system } } }]
+    ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+  - to: [{ ipBlock: { cidr: 0.0.0.0/0 } }]
+    ports: [{ protocol: TCP, port: 443 }]
+```
+
+### Applied to a kind (v1.33.0) cluster — PSS compliance confirmed
+`kubectl apply -f labs/lab7/k8s/` created every object and, critically, produced **no PodSecurity
+warnings** — if the spec violated the `restricted` profile, the namespace's `warn: restricted` label
+would have printed `Warning: would violate PodSecurity "restricted"`. It didn't:
+```
+namespace/juice-shop created
+serviceaccount/juice-shop created
+networkpolicy.networking.k8s.io/juice-shop-restricted created
+service/juice-shop created
+deployment.apps/juice-shop created          # ← no PSS warning = restricted-compliant
+```
+```
+NAME                          READY   STATUS     RESTARTS   AGE
+juice-shop-686f49cc7f-sqtqz   0/1     Init:0/1   0          ...   # initContainer seeding /juice-shop
+```
+
+> ⚠️ **Final `Running 1/1` + `trivy k8s` output not captured:** the local Docker Desktop engine
+> crashed under the combined load (kind control-plane + the ~600 MB initContainer copy + Juice Shop)
+> before the pod finished initialising — the same WSL2 engine instability seen in Lab 5. The spec is
+> validated (applies clean, PSS-compliant, initContainer running); the two commands below just need a
+> re-run on a stable engine to capture the final evidence:
+> ```bash
+> kubectl -n juice-shop wait --for=condition=ready pod -l app=juice-shop --timeout=300s
+> kubectl -n juice-shop get pod -l app=juice-shop
+> trivy k8s --include-namespaces juice-shop --severity HIGH,CRITICAL --report=summary
+> ```
+> Expected: pod `Running 1/1`; `trivy k8s` reports the same image CVEs (5 Critical / 43 High) with
+> **zero K8s-misconfiguration** HIGH/CRITICAL, because PSS restricted + the securityContext above
+> close every workload-level misconfig check.
+
+### What broke and how I fixed it (readOnlyRootFilesystem)
+`readOnlyRootFilesystem: true` breaks Juice Shop v20. I reproduced it with
+`docker run --read-only` and watched it fail progressively: it copies seed files into
+**`/juice-shop/ftp`**, opens its SQLite DB under **`/juice-shop/data`**, copies promo assets into
+**`/juice-shop/frontend/dist/...`**, and writes **`/juice-shop/.well-known/csaf/...`** — i.e. it
+writes all over its own install tree at startup, not just `/tmp`. The lab hint's "mount `/tmp` +
+logs" is not enough for v20. The clean fix: an **initContainer** (`node -e fs.cpSync`) copies the
+whole `/juice-shop` into a writable `emptyDir` owned by uid 1000, which the main container then
+mounts at `/juice-shop`; `fsGroup: 1000` gives the pod write access. The container root stays
+read-only — the app only writes inside its mounted volume (+ an `emptyDir` at `/tmp`). Verified via
+`docker run --read-only -v <vol>:/juice-shop --tmpfs /tmp` that the app clears every EROFS error.
+
+---
+
+## Bonus: Conftest Policy
+
+### Policy (`labs/lab7/policies/pod-hardening.rego`)
+```rego
+package main
+import rego.v1
+
+podspec := input.spec.template.spec
+
+deny contains msg if {
+	input.kind == "Deployment"
+	not podspec.securityContext.runAsNonRoot == true
+	msg := "pod securityContext.runAsNonRoot must be true"
+}
+deny contains msg if {
+	input.kind == "Deployment"
+	some c in podspec.containers
+	not c.securityContext.readOnlyRootFilesystem == true
+	msg := sprintf("container %q: securityContext.readOnlyRootFilesystem must be true", [c.name])
+}
+deny contains msg if {
+	input.kind == "Deployment"
+	some c in podspec.containers
+	not c.securityContext.allowPrivilegeEscalation == false
+	msg := sprintf("container %q: securityContext.allowPrivilegeEscalation must be false", [c.name])
+}
+deny contains msg if {
+	input.kind == "Deployment"
+	some c in podspec.containers
+	not drops_all(c)
+	msg := sprintf("container %q: securityContext.capabilities.drop must include \"ALL\"", [c.name])
+}
+drops_all(c) if { "ALL" in c.securityContext.capabilities.drop }
+```
+> Note the `not <field> == <value>` form (not `!=`): it also fires when the field is *absent*
+> (undefined), so a manifest with no `securityContext` at all is correctly caught.
+
+### PASS on the hardened manifest
+```
+conftest test labs/lab7/k8s/deployment.yaml --policy labs/lab7/policies
+4 tests, 4 passed, 0 warnings, 0 failures, 0 exceptions
+```
+
+### FAIL on a bad manifest (nginx Deployment, no securityContext)
+```
+FAIL - bad-pod.yaml - main - container "app": securityContext.allowPrivilegeEscalation must be false
+FAIL - bad-pod.yaml - main - container "app": securityContext.capabilities.drop must include "ALL"
+FAIL - bad-pod.yaml - main - container "app": securityContext.readOnlyRootFilesystem must be true
+FAIL - bad-pod.yaml - main - pod securityContext.runAsNonRoot must be true
+4 tests, 0 passed, 0 warnings, 4 failures, 0 exceptions
+```
+
+### What this prevents at CI time
+This policy catches **insecure-pod-spec bugs** (a container that could escalate to root, keep a
+writable root FS, or retain Linux capabilities) **before `kubectl apply` ever runs** — the
+shift-left half of the admission-control diagram (Lecture 7 slide 16). Catching it at CI-time beats
+catching it at admission-time because CI **fails the pull request**: the developer gets the feedback
+in seconds, in context, and the bad manifest never reaches the cluster's API server. Admission
+control (Kyverno/PSA) is the essential *backstop* for anything that bypasses CI, but by then the
+change is already merged and being deployed — a slower, noisier failure.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -101,36 +101,43 @@ networkpolicy.networking.k8s.io/juice-shop-restricted created
 service/juice-shop created
 deployment.apps/juice-shop created          # ← no PSS warning = restricted-compliant
 ```
+Also confirmed the enforcement is *live*, not just declarative: a `kubectl run` of a plain
+(non-compliant) pod into the namespace is **rejected at admission**:
 ```
-NAME                          READY   STATUS     RESTARTS   AGE
-juice-shop-686f49cc7f-sqtqz   0/1     Init:0/1   0          ...   # initContainer seeding /juice-shop
+Error from server (Forbidden): pods "cdtest" is forbidden: violates PodSecurity "restricted:latest":
+  allowPrivilegeEscalation != false, unrestricted capabilities, runAsNonRoot != true, seccompProfile ...
 ```
+So the restricted profile is both **satisfied by our Deployment** and **actively blocking** anything
+that isn't — the core Task 2 requirement.
 
-> ⚠️ **Final `Running 1/1` + `trivy k8s` output not captured:** the local Docker Desktop engine
-> crashed under the combined load (kind control-plane + the ~600 MB initContainer copy + Juice Shop)
-> before the pod finished initialising — the same WSL2 engine instability seen in Lab 5. The spec is
-> validated (applies clean, PSS-compliant, initContainer running); the two commands below just need a
-> re-run on a stable engine to capture the final evidence:
+> ⚠️ **`Running 1/1` + `trivy k8s` not captured — root cause isolated to the environment, not the
+> hardening.** The pod never reached Ready, and I traced why: (1) the local Docker Desktop engine
+> repeatedly crashed under kind load (same WSL2 instability as Lab 5); and (2) more fundamentally,
+> **a bare `juice-shop` Deployment with _no_ volumes and _no_ hardening also fails** in this kind /
+> containerd cluster — the distroless image's first startup gate, `validateDependenciesBasic.ts`
+> (`await import('check-dependencies')`), throws and prints *"Please run npm install…"*, even though
+> the **identical image runs fine under Docker**. This is an image↔containerd-runtime quirk on this
+> machine, independent of the securityContext or the volume design (proven by the minimal repro).
+> The manifest itself is validated: it applies clean, is PSS-restricted-compliant, and the
+> initContainer completes (`exitCode 0`). On a standard cluster the finish-line commands are:
 > ```bash
 > kubectl -n juice-shop wait --for=condition=ready pod -l app=juice-shop --timeout=300s
-> kubectl -n juice-shop get pod -l app=juice-shop
 > trivy k8s --include-namespaces juice-shop --severity HIGH,CRITICAL --report=summary
 > ```
-> Expected: pod `Running 1/1`; `trivy k8s` reports the same image CVEs (5 Critical / 43 High) with
-> **zero K8s-misconfiguration** HIGH/CRITICAL, because PSS restricted + the securityContext above
-> close every workload-level misconfig check.
 
 ### What broke and how I fixed it (readOnlyRootFilesystem)
-`readOnlyRootFilesystem: true` breaks Juice Shop v20. I reproduced it with
-`docker run --read-only` and watched it fail progressively: it copies seed files into
-**`/juice-shop/ftp`**, opens its SQLite DB under **`/juice-shop/data`**, copies promo assets into
-**`/juice-shop/frontend/dist/...`**, and writes **`/juice-shop/.well-known/csaf/...`** — i.e. it
-writes all over its own install tree at startup, not just `/tmp`. The lab hint's "mount `/tmp` +
-logs" is not enough for v20. The clean fix: an **initContainer** (`node -e fs.cpSync`) copies the
-whole `/juice-shop` into a writable `emptyDir` owned by uid 1000, which the main container then
-mounts at `/juice-shop`; `fsGroup: 1000` gives the pod write access. The container root stays
-read-only — the app only writes inside its mounted volume (+ an `emptyDir` at `/tmp`). Verified via
-`docker run --read-only -v <vol>:/juice-shop --tmpfs /tmp` that the app clears every EROFS error.
+`readOnlyRootFilesystem: true` genuinely breaks Juice Shop v20 — it writes all over its own install
+tree at startup, not just `/tmp`. I enumerated the exact paths two ways — `docker run --read-only`
+(watching each EROFS in turn) and reading the source (`lib/startup/restoreOverwrittenFilesWithOriginals.ts`,
+which copies `data/static/*` into `ftp/`, `i18n/`, and `frontend/dist/.../videos/`). The full writable
+set for v20 is: `/tmp`, `/juice-shop/ftp`, `/juice-shop/logs`, `/juice-shop/data` (SQLite DB **and**
+read-only seed files it needs), `/juice-shop/.well-known`, `/juice-shop/i18n`, and
+`/juice-shop/frontend/dist/frontend/assets/public/videos`. The fix in `deployment.yaml`: a writable
+`emptyDir` at each, plus an **initContainer** that copies *only* `/juice-shop/data` (small — no
+`node_modules`) into its emptyDir so the seeds survive alongside the writable SQLite path; `node_modules`
+and `build/` stay on the read-only image layer. `fsGroup: 1000` gives the pod ownership of the volumes.
+The container root stays read-only. (The whole-tree-copy alternative also works but drags ~600 MB of
+`node_modules` through an initContainer on every start — the per-path seed is leaner.)
 
 ---
 


### PR DESCRIPTION
- **feat(lab7): trivy image+config scan + PSS restricted manifests + conftest gate**
- **fix(lab7): per-path emptyDir seeding for readOnlyRootFS + isolate pod-run blocker to kind/containerd**
