### PR TITLE
feat(lab8): cosign sign + SBOM/provenance attestations + blob signing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Goal
+Describe what this PR delivers in one sentence.
+
+## Changes
+- Added / updated:
+  - `submissions/lab1.md`
+  - `.github/PULL_REQUEST_TEMPLATE.md`
+- Other changes:
+  - ...
+
+## Testing
+- Commands run:
+  - `docker run -d --name juice-shop -p 127.0.0.1:3000:3000 bkimminich/juice-shop:v20.0.0`
+  - `curl http://127.0.0.1:3000`
+- Observed output:
+  - HTTP 200 on `/`
+  - Juice Shop reachable at `http://127.0.0.1:3000`
+
+## Artifacts & Screenshots
+- `submissions/lab1.md`
+- Screenshots / links:
+  - ...
+  - ...
+
+## Checklist
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets or large temp files are committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/labs/lab8/keys/cosign.pub
+++ b/labs/lab8/keys/cosign.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW7PLY0hUjN4MTSctAWnxtn+/lzzo
+dWFsq2EmCx9fgwkGJWIlny8/Iya8zhTAmQFzl1OVnVcTtZBFO/Fq3w/ACg==
+-----END PUBLIC KEY-----

--- a/submissions/lab8.md
+++ b/submissions/lab8.md
@@ -1,0 +1,109 @@
+# Lab 8 — Submission
+
+## Task 1: Sign + Tamper Demo
+
+### Registry + image push
+- Registry container: `lab8-registry` running on `localhost:5000`
+- Image pushed: `localhost:5000/juice-shop:v20.0.0`
+- Image digest: `localhost:5000/juice-shop@sha256:28870b9d2bec49e605d6ebbf4b22ed1ec1ca0a72347ef19217bbbb21ea44e3fe`
+
+### Signing
+- Output of `cosign sign` (just the success line is fine):
+```
+Signing artifact...
+Pushing signature to: localhost:5000/juice-shop
+```
+
+### Verification (PASSED)
+Output of `cosign verify` on original digest:
+```json
+[{"critical":{"identity":{"docker-reference":"localhost:5000/juice-shop"},"image":{"docker-manifest-digest":"sha256:28870b9d2bec49e605d6ebbf4b22ed1ec1ca0a72347ef19217bbbb21ea44e3fe"},"type":"cosign container image signature"},"optional":null}]
+```
+
+### Tamper Demo (FAILED — correctly)
+Output of `cosign verify` on tampered digest:
+```
+WARNING: Skipping tlog verification is an insecure practice that lacks transparency and auditability verification for the signature.
+Error: no signatures found
+error during command execution: no signatures found
+```
+
+### Sanity — original still verifies
+```
+Verification for localhost:5000/juice-shop@sha256:28870b9d2bec49e605d6ebbf4b22ed1ec1ca0a72347ef19217bbbb21ea44e3fe --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - The signatures were verified against the specified public key
+
+[{"critical":{"identity":{"docker-reference":"localhost:5000/juice-shop"},"image":{"docker-manifest-digest":"sha256:28870b9d2bec49e605d6ebbf4b22ed1ec1ca0a72347ef19217bbbb21ea44e3fe"},"type":"cosign container image signature"},"optional":null}]
+```
+
+### Why digest binding matters (Lecture 8 slide 6)
+In the tamper demo, Alpine was re-tagged and pushed under a similar name, but its digest (`sha256:c64c687c...`) is different from the signed Juice Shop digest (`sha256:28870b9...`). Cosign signs the digest (`@sha256:...`), not the tag — Lecture 8 slide 6: tags are mutable, digests are not. If Cosign signed only the tag, an attacker could overwrite `:v20.0.0` in the registry with a malicious image and verification would still pass, because the tag name would match even though the content changed.
+
+---
+
+## Task 2: SBOM + Provenance Attestations
+
+### SBOM attestation
+- Attached: yes (`cosign attest --type cyclonedx` exit 0)
+- Verify-attestation output (first 30 lines of decoded payload):
+```json
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [
+    {
+      "name": "localhost:5000/juice-shop",
+      "digest": {
+        "sha256": "28870b9d2bec49e605d6ebbf4b22ed1ec1ca0a72347ef19217bbbb21ea44e3fe"
+      }
+    }
+  ],
+  "predicateType": "https://cyclonedx.org/bom",
+  "predicate": {
+    "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+    "bomFormat": "CycloneDX",
+    "components": [
+      {
+        "author": "Benjamin Byholm <bbyholm@abo.fi> (https://github.com/kkoopa/), Mathias Küsel (https://github.com/mathiask88/)",
+        "bom-ref": "pkg:npm/1to2@1.0.0?package-id=3cea2309a653e6ed",
+        "cpe": "cpe:2.3:a:nodejs:1to2:1.0.0:*:*:*:*:*:*:*",
+        "description": "NAN 1 -> 2 Migration Script",
+        ...
+      }
+    ]
+  }
+}
+```
+- Component count matches Lab 4 source: yes (Lab 4: 1846, attestation: 1846)
+- diff between Lab 4 SBOM and the extracted-from-attestation SBOM: `` (empty diff = success)
+
+### Provenance attestation
+- Attached: yes
+- Builder ID in predicate: `https://localhost/lab8-student`
+- buildType in predicate: `https://example.com/lab8/local-build`
+
+### What this gives a Lab 9 verifier (2-3 sentences)
+In Lab 9, Kyverno can require both a valid Cosign signature and specific attestations before a Pod is admitted. A signed image without an SBOM only proves who built it — not what libraries are inside. A signed image with a CycloneDX SBOM lets you search deployed images for a vulnerable dependency (e.g. Log4j) in minutes when the next Log4Shell hits.
+
+---
+
+## Bonus: Blob Signing (Codecov 2021 mitigation)
+
+### Sign + verify
+- Signed: `my-tool.tar.gz` + `my-tool.tar.gz.bundle`
+- Verify-blob success output:
+```
+WARNING: Skipping tlog verification is an insecure practice that lacks transparency and auditability verification for the blob.
+Verified OK
+```
+
+### Tamper test failed (correctly)
+```
+WARNING: Skipping tlog verification is an insecure practice that lacks transparency and auditability verification for the blob.
+Error: invalid signature when validating ASN.1 encoded signature
+error during command execution: invalid signature when validating ASN.1 encoded signature
+```
+
+### Codecov 2021 mitigation (2-3 sentences)
+In the Codecov 2021 incident, CI pipelines ran the bash uploader via `curl | bash` with no signature check. Running `cosign verify-blob --key cosign.pub --bundle uploader.bundle uploader.sh` before execution would fail on the tampered script. The pipeline would stop instead of running the attacker's code.


### PR DESCRIPTION
## Goal

Lab 8: sign the Juice Shop image with Cosign in a local registry, attach SBOM and provenance attestations, and demonstrate blob signing with `cosign sign-blob`.

## Changes

- Added / updated:
  - `submissions/lab8.md`
  - `labs/lab8/keys/cosign.pub`
- Other changes:
  - Task 1: local registry, image signing by digest, tamper demo (verify pass/fail)
  - Task 2: CycloneDX SBOM attestation + SLSA provenance attestation
  - Bonus: `my-tool.tar.gz` signed with `cosign sign-blob`, verify-blob pass + tamper fail

## Testing

- Commands run:
  - `docker run -d --name lab8-registry -p 127.0.0.1:5000:5000 registry:3`
  - `docker push localhost:5000/juice-shop:v20.0.0`
  - `cosign sign --key labs/lab8/keys/cosign.key --allow-insecure-registry --new-bundle-format=false --use-signing-config=false --tlog-upload=false --yes $DIGEST`
  - `cosign verify --key labs/lab8/keys/cosign.pub --insecure-ignore-tlog --allow-insecure-registry $DIGEST`
  - `cosign verify --key labs/lab8/keys/cosign.pub --insecure-ignore-tlog --allow-insecure-registry $TAMPERED_DIGEST`
  - `cosign attest --type cyclonedx --predicate labs/lab4/juice-shop.cdx.json $DIGEST`
  - `cosign attest --type slsaprovenance --predicate labs/lab8/predicate-only.json $DIGEST`
  - `cosign sign-blob --key labs/lab8/keys/cosign.key --bundle labs/lab8/results/my-tool.tar.gz.bundle labs/lab8/results/my-tool.tar.gz`
  - `cosign verify-blob --key labs/lab8/keys/cosign.pub --bundle my-tool.tar.gz.bundle my-tool.tar.gz`
- Observed output:
  - `Pushing signature to: localhost:5000/juice-shop`
  - Original digest verify: `The signatures were verified against the specified public key`
  - Tampered digest verify: `Error: no signatures found`
  - SBOM component count: 1846 (matches Lab 4)
  - Blob verify: `Verified OK`
  - Tampered blob verify: `Error: invalid signature when validating ASN.1 encoded signature`

## Artifacts & Screenshots

- `submissions/lab8.md`
- `labs/lab8/keys/cosign.pub`
- Screenshots / links:
  - Verification outputs saved in `submissions/lab8.md` (Task 1, Task 2, Bonus)

## Checklist

- [x] Title is clear (`feat(labN): <topic>` style)
- [x] No secrets or large temp files are committed
- [x] Submission file at `submissions/labN.md` exists
- [x] Task 1 — Image signed + tamper demo (both shown)
- [x] Task 2 — SBOM + provenance attestations attached and verified
- [x] Bonus — Blob signed + verify-blob success + tamper failure