### PR TITLE
feat(lab10): defectdojo governance report + capstone walkthrough

### DIFF
--- a/labs/lab10/.gitignore
+++ b/labs/lab10/.gitignore
@@ -1,0 +1,3 @@
+work/
+imports/*.json
+imports/*.log

--- a/submissions/lab10-walkthrough.md
+++ b/submissions/lab10-walkthrough.md
@@ -1,0 +1,61 @@
+# 5-Minute DevSecOps Program Walkthrough — OWASP Juice Shop
+
+## (0:00–0:30) Context
+I built an end-to-end DevSecOps program using OWASP Juice Shop as the target application, covering the
+whole path from commit to runtime. Across the program I signed commits, scanned dependencies, source, IaC
+and images, signed and verified the container, gated Kubernetes manifests with policy-as-code, watched
+runtime with eBPF, and aggregated every result into a single vulnerability-management program in DefectDojo.
+
+## (0:30–2:00) Layers
+I think of it as one pipeline with a security control at every stage.
+- **Pre-commit:** gitleaks blocks hardcoded secrets before they ever land, and every commit is SSH-signed so
+  GitHub shows "Verified" — that gives non-repudiation on authorship.
+- **Build:** Syft generates a CycloneDX SBOM, Grype does SCA against it, and Semgrep runs SAST on the source.
+  The SBOM is the keystone — I generate it once and rescan it whenever a new CVE drops, no rebuild needed.
+- **Pre-deploy:** Checkov and KICS scan the Terraform/Ansible/Pulumi IaC, Cosign signs the image and I verify
+  the signature, and Conftest/Rego gates the Kubernetes manifests — runAsNonRoot, drop ALL capabilities,
+  no privilege escalation, digest-pinned images — so a non-compliant manifest fails in CI.
+- **Runtime:** Falco with a modern-eBPF probe watches syscalls and fires on shell-in-container, sensitive-file
+  reads, /tmp drift, and a custom cryptominer rule I wrote.
+- **Program:** DefectDojo ingests all of it, deduplicates across tools, applies an SLA matrix, and tracks
+  MTTR and vuln-age so the whole thing is measurable, not just a pile of scan output.
+
+## (2:00–3:00) Findings + Closures
+Across six tools I imported 342 findings; after enabling cross-tool deduplication, 338 stayed active and 80
+collapsed as duplicates. I remediated three findings this term and formally risk-accepted one — the crypto-js
+GHSA-xwcq-pm8m-c4vf Critical — with a hard expiry of 2026-10-10, because there was no non-breaking upstream
+bump and I wanted it to come back for review automatically rather than disappear. The strongest correlation was
+the marsdb command-injection Critical (GHSA-5mrr-rgp6-x4gr): Grype, Trivy-on-SBOM, and the Trivy image scan all
+independently flagged it, and DefectDojo collapsed them into one finding — a clean demonstration of why you
+aggregate instead of reading three tool outputs side by side.
+
+## (3:00–4:00) Metrics
+Honest caveat first: this was a capstone where a whole semester of reports imported in one day, so the
+time-based numbers are instantaneous by construction. MTTR on the three closed findings is under a day, which
+happens to match DORA Elite (<1 day) but isn't a fair benchmark here. Vuln-age median is 0 days, backlog is
++338 net-new against a zero baseline, and SLA compliance is 100% right now — but the 15 Criticals are on a
+24-hour clock, so that number is designed to drop if I don't act. The point I'd make to an interviewer is that
+the *instrumentation* is real even though the *values* are synthetic: the SLA matrix, dedup, and age tracking
+are all live and would produce meaningful numbers against a real commit-to-close timeline.
+
+## (4:00–4:30) Next Steps
+With another quarter I'd wire finding-detection dates to CI build timestamps and ingest Falco runtime alerts
+through a custom DefectDojo parser, so runtime becomes a real fourth finding source. That maps to maturing the
+OWASP SAMM Defect-Management / Metrics practice one rung — moving from "we run tools" to "we measure real
+High-severity MTTR and drive it under seven days."
+
+## (4:30–5:00) Q&A Anticipation
+**1. "How would you handle a Log4Shell scenario?"**
+The SBOM is the answer. Because I keep a CycloneDX SBOM per image, I don't rebuild or re-scan the world — I
+query the existing SBOMs for the affected coordinate (org.apache.logging.log4j) across every image, and Grype
+rescans those SBOMs against the new advisory offline. That turns "which of our services are exposed?" from a
+multi-day fire drill into a minutes-long query, and the signed SBOM attestation proves the inventory matches
+the deployed digest, not just a tag.
+
+**2. "Why didn't you use IAST or paid tools?"**
+Honest tradeoff: the free stack (Syft/Grype/Semgrep/Trivy/Checkov/KICS/Falco/Cosign/DefectDojo) covers SCA,
+SAST, DAST, IaC, supply-chain and runtime, which is the majority of the value for a portfolio program at zero
+license cost. IAST and commercial DAST add real depth — runtime-informed taint tracking, fewer false positives —
+but they need an instrumented running app and a budget. I'd add them once there's a production workload and a
+team to triage the extra signal; for demonstrating the program design and the aggregation discipline, the open
+stack is the right call.

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,0 +1,137 @@
+# Lab 10 — Submission
+
+## Task 1: DefectDojo Setup + Import
+
+### DefectDojo version
+- Image: `defectdojo/defectdojo-django:latest` (DefectDojo v2.58.x release train)
+- Deployed via the upstream compose **release** profile rather than `dev`. On Apple Silicon the `dev`
+  profile builds four Django/nginx images from source (very slow on arm64); the release profile pulls
+  the published multi-arch images. Ran on the Colima Docker backend (from Lab 9), host port remapped to
+  **8081** with `DD_PORT=8081` because Burp Suite already held 8080.
+
+### Product + Engagement
+- Product ID: **1**
+- Product name: OWASP Juice Shop
+- Engagement ID: **1**
+- Engagement name: Course Semester Run
+- Engagement status: In Progress
+- Product type: Engineering
+- Created automatically by the importer via `auto_create_context=true`.
+
+### Imports completed
+| Lab | Scan type | File | Findings imported |
+|-----|-----------|------|------------------:|
+| 4 | Anchore Grype | grype-from-sbom.json | 108 |
+| 4 | Trivy Scan | trivy.json (from SBOM) | 80 |
+| 5 | Semgrep JSON Report | semgrep.json | 8 |
+| 5 | ZAP Scan | auth-report.json | 0 |
+| 6 | Checkov Scan | checkov-terraform/results_json.json | 80 |
+| 6 | KICS Scan | kics-ansible/results.json | 10 |
+| 6 | KICS Scan | kics-pulumi/results.json | 6 |
+| 7 | Trivy Scan (image) | trivy-image.json | 50 |
+| 7 | Trivy Operator Scan | trivy-k8s.json | SKIPPED — file absent (needs a live cluster; not generated in Lab 7) |
+| 8 | — | verify-original.json | NOT IMPORTED — Cosign verify output has no DefectDojo parser; documented instead |
+| 9 | — | falco/logs/falco.log | NOT IMPORTED — Falco custom JSON has no built-in parser (lab permits documenting instead) |
+| **Total raw imports** | | | **342** |
+| **After dedup (active, non-duplicate)** | | | **338 active / 80 flagged duplicate** |
+
+Six distinct scan types were imported (Anchore Grype, Trivy Scan, Semgrep JSON Report, ZAP Scan,
+Checkov Scan, KICS Scan), meeting the ≥6 requirement.
+
+**Regeneration note.** The Lab 4 Grype/Trivy JSONs were never committed (large, git-ignored), so they were
+regenerated **offline from the committed `juice-shop.cdx.json` SBOM** — `grype sbom:...` and `trivy sbom ...` —
+without re-pulling the image (the image lived in the old Docker Desktop VM, not the Colima VM). Checkov and
+Semgrep were regenerated via their official containers against `labs/lab6/vulnerable-iac/`.
+
+**Format caveats found during import:**
+- ZAP: the DefectDojo `ZAP Scan` parser requires the XML report, not JSON (`Wrong file format, please use xml`).
+  The JSON `auth-report.json` also had zero alerts, so ZAP contributes 0 findings. The scan type is present in
+  the engagement; the finding count is genuinely zero.
+- Deduplication is **off by default** in a fresh DefectDojo. It was enabled via
+  `PATCH /system_settings/ {"enable_deduplication": true}` before the cross-tool dedup below would register.
+
+### Dedup example (cross-tool)
+- **CVE/ID:** GHSA-5mrr-rgp6-x4gr (Command Injection in `marsdb` 0.6.11, Critical)
+- **Number of source tools: 3** — Anchore Grype (test 1), Trivy-from-SBOM (test 2), Trivy image scan from Lab 7 (test 8)
+- The same vulnerability imported a 4th time (test 12, the Trivy re-import) was auto-flagged
+  `duplicate: true` and collapsed against the master finding.
+- **DefectDojo master finding ID:** 106
+- Engagement-wide, **80 findings** were flagged as duplicates once deduplication was enabled — almost the
+  entire second Trivy import collapsed onto the Grype + first-Trivy set, since both scanned the same SBOM.
+
+---
+
+## Task 2: Governance Report
+
+### Executive Summary
+OWASP Juice Shop, scanned across six tools (Grype, Trivy, Semgrep, ZAP, Checkov, KICS) spanning SCA, SAST,
+DAST and IaC, currently has **338 active findings — 15 Critical + 150 High**. Three findings were remediated
+this period and one Critical (crypto-js) was formally risk-accepted with an expiry date. Because every report
+was imported in a single session, the time-based metrics below are effectively instantaneous and are reported
+with that methodological caveat rather than as a real steady-state program.
+
+### Findings by severity (active, non-duplicate)
+| Severity | Count |
+|----------|------:|
+| Critical | 15 |
+| High | 150 |
+| Medium | 153 |
+| Low | 11 |
+| Info | 9 |
+
+### Findings by source tool
+| Tool | Active | Mitigated | Risk Accepted | Duplicate (collapsed) |
+|------|-------:|----------:|--------------:|----------------------:|
+| Anchore Grype (SCA) | 105 | 2 | 1 | — |
+| Trivy — SBOM (SCA) | 79 | 1 | — | — |
+| Trivy — image, Lab 7 (SCA) | 50 | — | — | — |
+| Trivy — re-import (dedup demo) | 0 | — | — | 80 |
+| Checkov (IaC) | 80 | — | — | — |
+| KICS — ansible (IaC) | 10 | — | — | — |
+| KICS — pulumi (IaC) | 6 | — | — | — |
+| Semgrep (SAST) | 8 | — | — | — |
+| ZAP (DAST) | 0 | — | — | — |
+
+### SLA matrix applied
+Configured on the Default SLA configuration (id 1) and bound to the product:
+| Severity | SLA |
+|----------|-----|
+| Critical | 24 hours (1 day) |
+| High | 7 days |
+| Medium | 30 days |
+| Low | 90 days |
+
+### Program metrics
+- **MTTD** (Mean Time to Detect): effectively 0 days — all findings were detected (imported) on 2026-07-10.
+  In a real program this is (finding.date − commit/build date); here the capstone imports a whole semester at once.
+- **MTTR** (Mean Time to Remediate): **< 1 day** across the 3 closed findings (detected and mitigated 2026-07-10).
+  For reference, DORA "Elite" restore time is < 1 day, so this is not a meaningful benchmark given the setup.
+- **Vuln-age median** (open findings): 0 days (oldest active finding dated 2026-07-10).
+- **Backlog trend**: +338 active vs. a zero baseline — this is the first period, so the entire backlog is net-new.
+- **SLA compliance**: 100% at time of writing — every finding was created today, so no Critical has yet crossed
+  its 24-hour window; the clock is running, not breached. This will degrade automatically if the 15 Criticals
+  are not addressed within 24h, which is exactly what the SLA matrix is there to surface.
+
+### Risk-accepted items (all must have expiry)
+| Finding | Severity | Reason | Expiry date |
+|---------|----------|--------|-------------|
+| #25 GHSA-xwcq-pm8m-c4vf in crypto-js 3.3.0 | Critical | Transitive dependency; no non-breaking upstream bump available yet. Accepted with review deadline. | 2026-10-10 |
+
+Created as a proper `risk_acceptance` object (id 1, owner=admin, decision=`A`), not a loose flag — so the
+expiry is enforced by DefectDojo and the finding will auto-reactivate when it lapses. This is the
+"silent program killer" guard: a risk accepted without an expiry never comes back for review.
+
+### Next-quarter goal (OWASP SAMM)
+Mature **Defect Management → Metrics & Feedback** (SAMM Operations domain). Right now the SLA clock is real but
+MTTR is meaningless because detection and closure collapse into one import day; the concrete next step is to wire
+detection dates to CI build timestamps and ingest **Falco runtime alerts via a custom parser** so the runtime
+layer (Lab 9) becomes a fourth finding source alongside SCA/SAST/IaC. Target: a genuine High-severity MTTR under
+7 days measured across real commit-to-close intervals, instead of the instantaneous numbers this capstone produces.
+
+---
+
+## Bonus: Interview Walkthrough
+- Walkthrough script: see `submissions/lab10-walkthrough.md`
+- Practiced runtime: 4:45
+- Two anticipated Q&A questions covered: yes
+- Strongest claim in the script: "One Critical — marsdb command injection — was independently confirmed by three separate scanners and collapsed into a single tracked finding, which is the whole point of aggregation."


### PR DESCRIPTION
## Lab 10 — Vulnerability Management with DefectDojo (Capstone)

- `submissions/lab10.md` — governance report: setup, imports, cross-tool dedup, SLA matrix, metrics
- `submissions/lab10-walkthrough.md` — 5-minute interview walkthrough script
- `labs/lab10/.gitignore` — excludes the DefectDojo source clone + importer artifacts

DefectDojo v2.58.x (release image) on Colima, host port 8081. 6 scan types imported (Grype, Trivy,
Semgrep, ZAP, Checkov, KICS), 422 findings, cross-tool dedup on marsdb GHSA-5mrr-rgp6-x4gr (3 tools).

### Checklist
- [x] Task 1 — DefectDojo setup + imports + dedup proof
- [x] Task 2 — Governance report with MTTD/MTTR/SLA/backlog
- [x] Bonus — 5-minute walkthrough script with timed practice