### PR TITLE
feat(lab11): hardened nginx + WAF sidecar

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Goal
+
+Briefly describe what this PR delivers.
+
+## Changes
+
+- Added:
+- Modified:
+- Updated:
+
+## Testing
+
+Commands executed and observed results:
+
+```
+<paste commands and outputs here>
+```
+
+## Artifacts & Screenshots
+
+- Submission file:
+- Screenshots:
+- Additional artifacts:
+
+## Checklist
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/labs/lab11/reverse-proxy/nginx.conf
+++ b/labs/lab11/reverse-proxy/nginx.conf
@@ -1,127 +1,128 @@
-user  nginx;
-worker_processes  auto;
+user nginx;
+worker_processes auto;
 
-events { worker_connections 1024; }
+events {
+    worker_connections 1024;
+}
 
 http {
-  include       /etc/nginx/mime.types;
-  default_type  application/octet-stream;
-  sendfile      on;
-  keepalive_timeout  10;
-  server_tokens off;
-  gzip off;
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-  # Security-focused logs
-  log_format security '$remote_addr - $remote_user [$time_local] '
-                     '"$request" $status $body_bytes_sent '
-                     '"$http_referer" "$http_user_agent" '
-                     'rt=$request_time uct=$upstream_connect_time '
-                     'urt=$upstream_response_time';
-  access_log /var/log/nginx/access.log security;
-  error_log  /var/log/nginx/error.log warn;
-
-  # Upstream app
-  upstream juice {
-    server juice:3000;
-    keepalive 32;
-  }
-
-  # Rate limit zone for login
-  # ~10 req/min per IP, burst of 5
-  limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
-  limit_req_status 429;
-
-  map $http_upgrade $connection_upgrade { default upgrade; '' close; }
-
-  # Common proxy settings
-  proxy_set_header Host $host;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
-  proxy_http_version 1.1;
-  proxy_set_header Connection $connection_upgrade;
-  proxy_set_header Upgrade $http_upgrade;
-  # Prevent upstream TLS BREACH vector by disabling compression from upstream
-  proxy_set_header Accept-Encoding "";
-  proxy_read_timeout 30s;
-  proxy_send_timeout 30s;
-  proxy_connect_timeout 5s;
-  proxy_hide_header X-Powered-By;
-  # Hide upstream headers to avoid duplicates and enforce policy at the proxy
-  proxy_hide_header X-Frame-Options;
-  proxy_hide_header X-Content-Type-Options;
-  proxy_hide_header Referrer-Policy;
-  proxy_hide_header Permissions-Policy;
-  proxy_hide_header Cross-Origin-Opener-Policy;
-  proxy_hide_header Cross-Origin-Resource-Policy;
-  proxy_hide_header Content-Security-Policy;
-  proxy_hide_header Content-Security-Policy-Report-Only;
-  proxy_hide_header Access-Control-Allow-Origin;
-
-  # HTTP server (redirect to HTTPS)
-  server {
-    listen 8080;
-    listen [::]:8080;
-    server_name _;
-
-    # Core headers (also on redirects)
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
-
-    return 308 https://$host:8443$request_uri;
-  }
-
-  # HTTPS server
-  server {
-    listen 8443 ssl;
-    listen [::]:8443 ssl;
-    http2 on;
-    server_name _;
-
-    ssl_certificate     /etc/nginx/certs/localhost.crt;
-    ssl_certificate_key /etc/nginx/certs/localhost.key;
-    ssl_session_timeout 10m;
-    ssl_session_cache   shared:SSL:10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:EECDH+AESGCM:EDH+AESGCM";
-    ssl_prefer_server_ciphers on;
-    ssl_stapling off;
-    # If using a publicly-trusted certificate, you may enable OCSP stapling:
-    # ssl_stapling on;
-    # ssl_stapling_verify on;
-    # resolver 1.1.1.1 8.8.8.8 valid=300s;
-    # resolver_timeout 5s;
-    # ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
-
-    client_max_body_size 2m;
-    client_body_timeout 10s;
-    client_header_timeout 10s;
+    sendfile on;
+    server_tokens off;
+    gzip off;
     keepalive_timeout 10s;
-    send_timeout 10s;
 
-    # Security headers (include HSTS here only)
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+    log_format security '$remote_addr - $remote_user [$time_local] '
+                        '"$request" $status $body_bytes_sent '
+                        '"$http_referer" "$http_user_agent" '
+                        'rt=$request_time '
+                        'uct=$upstream_connect_time '
+                        'urt=$upstream_response_time';
 
-    location = /rest/user/login {
-      limit_req zone=login burst=5 nodelay;
-      limit_req_log_level warn;
-      proxy_pass http://juice;
+    access_log /var/log/nginx/access.log security;
+    error_log /var/log/nginx/error.log warn;
+
+    upstream juice {
+        server juice:3000;
+        keepalive 32;
     }
 
-    location / {
-      proxy_pass http://juice;
+    limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
+    limit_req_status 429;
+
+    limit_conn_zone $binary_remote_addr zone=conn:10m;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
     }
-  }
+
+    proxy_http_version 1.1;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Accept-Encoding "";
+
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 30s;
+    proxy_send_timeout 30s;
+
+    proxy_hide_header X-Powered-By;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Permissions-Policy;
+    proxy_hide_header Content-Security-Policy;
+    proxy_hide_header Content-Security-Policy-Report-Only;
+
+    server {
+        listen 8080;
+        listen [::]:8080;
+        server_name _;
+
+        return 308 https://$host:8443$request_uri;
+    }
+
+    server {
+        listen 8443 ssl;
+        listen [::]:8443 ssl;
+        http2 on;
+
+        server_name _;
+
+        limit_conn conn 50;
+
+        ssl_certificate /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+
+        ssl_protocols TLSv1.3;
+        ssl_prefer_server_ciphers off;
+
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+        ssl_ecdh_curve X25519:secp384r1;
+
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 1d;
+        ssl_session_tickets off;
+
+        # OCSP stapling is disabled for the self-signed lab certificate.
+        # Production example:
+        #
+        # ssl_stapling on;
+        # ssl_stapling_verify on;
+        # resolver 8.8.8.8 1.1.1.1 valid=300s;
+        # resolver_timeout 5s;
+        # ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+
+        client_max_body_size 2m;
+        client_body_timeout 10s;
+        client_header_timeout 10s;
+        send_timeout 10s;
+        keepalive_timeout 10s;
+
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' ws: wss:" always;
+
+        location = /rest/user/login {
+            limit_req zone=login burst=5 nodelay;
+            limit_req_log_level warn;
+
+            proxy_pass http://juice;
+        }
+
+        location / {
+            proxy_pass http://juice;
+        }
+    }
 }

--- a/labs/lab11/waf/docker-compose.waf.yml
+++ b/labs/lab11/waf/docker-compose.waf.yml
@@ -1,0 +1,33 @@
+services:
+  waf:
+    image: owasp/modsecurity-crs:4.25.1-nginx-lts
+    restart: unless-stopped
+    depends_on:
+      - nginx
+    ports:
+      - "8082:8080"
+    environment:
+      BACKEND: "https://nginx:8443"
+      PORT: "8080"
+
+      MODSEC_RULE_ENGINE: "On"
+      MODSEC_REQ_BODY_ACCESS: "On"
+
+      BLOCKING_PARANOIA: "1"
+      DETECTION_PARANOIA: "1"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+
+      MODSEC_AUDIT_ENGINE: "RelevantOnly"
+      MODSEC_AUDIT_LOG: "/dev/stdout"
+      MODSEC_AUDIT_LOG_FORMAT: "JSON"
+      MODSEC_AUDIT_LOG_TYPE: "Serial"
+
+      PROXY_SSL_VERIFY: "off"
+      PROXY_SSL_PROTOCOLS: "TLSv1.3"
+
+      SERVER_NAME: "localhost"
+      SERVER_TOKENS: "off"
+
+    networks:
+      - default

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,304 @@
+# Lab 11 — Reverse Proxy Hardening
+
+## Overview
+
+The OWASP Juice Shop application is placed behind a hardened Nginx reverse proxy.
+
+The main architecture is:
+
+~~~text
+Client
+  |
+  +-- http://localhost:8080
+  |       |
+  |       +-- 308 redirect to HTTPS
+  |
+  +-- https://localhost:8443
+          |
+          +-- hardened Nginx
+                  |
+                  +-- Juice Shop:3000
+~~~
+
+The bonus WAF architecture is:
+
+~~~text
+Client
+  |
+  +-- http://localhost:8082
+          |
+          +-- ModSecurity v3 + OWASP CRS v4
+                  |
+                  +-- https://nginx:8443
+                          |
+                          +-- Juice Shop:3000
+~~~
+
+## Task 1 — HTTPS and security headers
+
+### HTTP to HTTPS redirect
+
+Nginx listens on port `8080` and permanently redirects all requests to HTTPS on port `8443`.
+
+Observed result:
+
+~~~text
+HTTP/1.1 308 Permanent Redirect
+Location: https://localhost:8443/
+~~~
+
+### TLS configuration
+
+The reverse proxy accepts only TLS 1.3:
+
+~~~nginx
+ssl_protocols TLSv1.3;
+~~~
+
+Observed negotiation:
+
+~~~text
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_256_GCM_SHA384
+Peer Temp Key: X25519, 253 bits
+~~~
+
+A TLS 1.2 connection was rejected with a protocol-version alert.
+
+The certificate is self-signed because this is a local laboratory environment. It contains SAN entries for `localhost`, `juice.local`, and `127.0.0.1`.
+
+### Security headers
+
+The following headers are added by Nginx:
+
+1. `Strict-Transport-Security`
+2. `X-Content-Type-Options`
+3. `X-Frame-Options`
+4. `Referrer-Policy`
+5. `Permissions-Policy`
+6. `Content-Security-Policy-Report-Only`
+
+Observed values:
+
+~~~text
+strict-transport-security: max-age=63072000; includeSubDomains; preload
+x-content-type-options: nosniff
+x-frame-options: DENY
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: camera=(), microphone=(), geolocation=()
+content-security-policy-report-only: default-src 'self'; ...
+~~~
+
+CSP is initially deployed in report-only mode. This allows violations and incompatible application resources to be discovered before enforcement is enabled.
+
+## Task 2 — Reverse proxy hardening
+
+### Rate limiting
+
+Requests to the authentication endpoint are limited by client IP:
+
+~~~nginx
+limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
+limit_req zone=login burst=5 nodelay;
+limit_req_status 429;
+~~~
+
+During a parallel test with 60 login attempts, the result was:
+
+~~~text
+6 401
+54 429
+~~~
+
+This confirms that requests above the configured limit are rejected with HTTP `429 Too Many Requests`.
+
+### Connection limiting
+
+The number of simultaneous connections per client IP is limited:
+
+~~~nginx
+limit_conn_zone $binary_remote_addr zone=conn:10m;
+limit_conn conn 50;
+~~~
+
+### Timeout protection
+
+The following timeout values are configured:
+
+~~~nginx
+client_body_timeout 10s;
+client_header_timeout 10s;
+send_timeout 10s;
+keepalive_timeout 10s;
+
+proxy_connect_timeout 5s;
+proxy_read_timeout 30s;
+proxy_send_timeout 30s;
+~~~
+
+A TLS client sent incomplete HTTP headers and kept the connection open.
+
+Observed result:
+
+~~~text
+Connection closed by Nginx without a response.
+Elapsed seconds: 9.88
+~~~
+
+This demonstrates protection against slow-header and Slowloris-style connections.
+
+### Cipher suites and curves
+
+TLS 1.3 cipher suites are explicitly restricted:
+
+~~~nginx
+ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+ssl_ecdh_curve X25519:secp384r1;
+~~~
+
+Observed connection:
+
+~~~text
+Ciphersuite: TLS_AES_256_GCM_SHA384
+Peer Temp Key: X25519, 253 bits
+~~~
+
+### TLS session hardening
+
+~~~nginx
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 1d;
+ssl_session_tickets off;
+~~~
+
+Session tickets are disabled so that ticket-key rotation is not required and old ticket keys cannot be used to recover previous TLS sessions.
+
+## Certificate rotation
+
+For production, certificates should be issued by an automated ACME client or an internal PKI.
+
+A safe rotation procedure is:
+
+1. Request or generate a new certificate and private key.
+2. Verify the certificate hostname, SAN values, expiration date, and certificate chain.
+3. Store the new files with restrictive permissions.
+4. Replace the certificate files atomically.
+5. Run `nginx -t`.
+6. Reload Nginx with `nginx -s reload`.
+7. Verify the new certificate using `openssl s_client`.
+8. Retain the previous certificate briefly to allow rollback.
+
+Reloading Nginx is preferable to restarting it because existing connections can finish while new workers load the updated certificate.
+
+Private keys must not be committed to Git. The local certificate directory is excluded using `.gitignore`.
+
+## OCSP stapling
+
+OCSP stapling is not enabled for the laboratory certificate because it is self-signed and has no public certificate authority or OCSP responder.
+
+In production, OCSP stapling can be enabled with:
+
+~~~nginx
+ssl_stapling on;
+ssl_stapling_verify on;
+ssl_trusted_certificate /path/to/full-chain.pem;
+resolver 1.1.1.1 8.8.8.8 valid=300s;
+resolver_timeout 5s;
+~~~
+
+The server periodically retrieves a signed certificate-status response from the CA and sends it during the TLS handshake. This improves privacy and reduces the need for each client to contact the CA directly.
+
+The full issuer chain and a reachable OCSP responder are required.
+
+## Bonus — ModSecurity and OWASP CRS
+
+The WAF uses:
+
+~~~text
+Image: owasp/modsecurity-crs:4.25.1-nginx-lts
+ModSecurity: 3.0.16
+ModSecurity Nginx connector: 1.0.4
+OWASP CRS: 4.25.1
+Blocking Paranoia Level: 1
+Detection Paranoia Level: 1
+Inbound anomaly threshold: 5
+~~~
+
+The WAF runs in blocking mode:
+
+~~~yaml
+MODSEC_RULE_ENGINE: "On"
+BLOCKING_PARANOIA: "1"
+DETECTION_PARANOIA: "1"
+ANOMALY_INBOUND: "5"
+~~~
+
+### WAF verification
+
+The same SQL injection payload was sent directly to Nginx and through the WAF:
+
+~~~text
+1' OR '1'='1
+~~~
+
+Direct request:
+
+~~~text
+https://localhost:8443/rest/products/search
+HTTP status: 200
+~~~
+
+Request through ModSecurity:
+
+~~~text
+http://localhost:8082/rest/products/search
+HTTP status: 403
+~~~
+
+The audit log recorded:
+
+~~~text
+Rule 942100 — SQL Injection Attack Detected via libinjection
+Rule 949110 — Inbound Anomaly Score Exceeded
+Total inbound anomaly score: 5
+HTTP response: 403
+~~~
+
+Therefore, the request is accepted by the ordinary reverse proxy but blocked when it passes through ModSecurity and OWASP CRS.
+
+## WAF trade-offs
+
+A WAF provides an additional security layer, but it does not replace secure application code.
+
+Main trade-offs include:
+
+- false positives that may block legitimate requests;
+- additional latency and CPU usage;
+- larger log volume;
+- the need to update CRS regularly;
+- application-specific rule exclusions;
+- testing requirements before increasing the paranoia level.
+
+Paranoia Level 1 was selected because it provides baseline protection with a relatively low false-positive rate.
+
+In production, WAF rules should first be evaluated in detection mode. After reviewing audit logs, narrowly scoped exclusions can be created for known legitimate requests. Entire rule groups should not be disabled unless strictly necessary.
+
+## Verification summary
+
+| Control | Result |
+|---|---|
+| HTTP to HTTPS redirect | Passed — HTTP 308 |
+| TLS 1.3 only | Passed |
+| TLS 1.2 rejected | Passed |
+| Security headers | Passed — 6 headers |
+| Login rate limiting | Passed — HTTP 429 |
+| Connection limiting | Configured |
+| Slow-header timeout | Passed — connection closed after 9.88 seconds |
+| Restricted TLS ciphers | Passed |
+| X25519 key exchange | Passed |
+| Session tickets disabled | Passed |
+| ModSecurity enabled | Passed |
+| OWASP CRS v4 enabled | Passed |
+| WAF blocking test | Passed — HTTP 403 |
+| Audit rule ID | 942100 |
+| Blocking rule ID | 949110 |


### PR DESCRIPTION
## Goal

Deliver Lab 11 reverse proxy hardening for OWASP Juice Shop using Nginx, TLS 1.3, security headers, rate limiting, timeout protections, TLS hardening, certificate rotation guidance, and a ModSecurity WAF with OWASP CRS.

## Changes

- Added:
  - `labs/lab11/waf/docker-compose.waf.yml`
  - ModSecurity v3 with OWASP CRS 4.25.1
  - WAF blocking mode with Paranoia Level 1
  - `submissions/lab11.md` with configuration details, test results, certificate rotation runbook, OCSP explanation, and WAF trade-offs
- Modified:
  - `labs/lab11/reverse-proxy/nginx.conf`
  - Enabled TLS 1.3 only
  - Added six security headers
  - Added login rate limiting and connection limiting
  - Added client and upstream timeouts
  - Restricted TLS 1.3 cipher suites and elliptic curves
  - Disabled TLS session tickets
- Updated:
  - HTTP-to-HTTPS redirect behavior
  - Reverse proxy security configuration
  - WAF audit logging through container stdout

## Testing

Commands executed and observed results:

~~~bash
docker compose \
  -f labs/lab11/docker-compose.yml \
  exec -T nginx nginx -t
~~~

~~~text
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
~~~

~~~bash
curl -sI http://localhost:8080/
~~~

~~~text
HTTP/1.1 308 Permanent Redirect
Location: https://localhost:8443/
~~~

~~~bash
echo | openssl s_client \
  -connect localhost:8443 \
  -servername localhost \
  -tls1_3 \
  -brief
~~~

~~~text
Protocol version: TLSv1.3
Ciphersuite: TLS_AES_256_GCM_SHA384
Peer Temp Key: X25519, 253 bits
~~~

~~~bash
echo | openssl s_client \
  -connect localhost:8443 \
  -servername localhost \
  -tls1_2 \
  -brief
~~~

~~~text
TLS 1.2 rejected with protocol version alert
~~~

~~~bash
curl -skI https://localhost:8443/
~~~

~~~text
strict-transport-security: max-age=63072000; includeSubDomains; preload
x-content-type-options: nosniff
x-frame-options: DENY
referrer-policy: strict-origin-when-cross-origin
permissions-policy: camera=(), microphone=(), geolocation=()
content-security-policy-report-only: default-src 'self'; ...
~~~

~~~bash
seq 1 60 | xargs -P 30 -I{} curl -sk \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"email":"test@example.com","password":"invalid"}' \
  -o /dev/null \
  -w "%{http_code}\n" \
  https://localhost:8443/rest/user/login \
  | sort | uniq -c
~~~

~~~text
6 401
54 429
~~~

~~~text
Slow-header test:
Connection closed by Nginx without a response.
Elapsed seconds: 9.88
~~~

~~~bash
curl -sk \
  --get \
  --data-urlencode "q=1' OR '1'='1" \
  -o /dev/null \
  -w "%{http_code}\n" \
  https://localhost:8443/rest/products/search
~~~

~~~text
200
~~~

~~~bash
curl -s \
  --get \
  --data-urlencode "q=1' OR '1'='1" \
  -o /dev/null \
  -w "%{http_code}\n" \
  http://localhost:8082/rest/products/search
~~~

~~~text
403
~~~

~~~text
WAF audit log:
Rule 942100 — SQL Injection Attack Detected via libinjection
Rule 949110 — Inbound Anomaly Score Exceeded
Inbound anomaly score: 5
~~~

## Artifacts & Screenshots

- Submission file:
  - `submissions/lab11.md`
- Screenshots:
  - Not required; command outputs and WAF audit evidence are included in the submission file
- Additional artifacts:
  - `labs/lab11/reverse-proxy/nginx.conf`
  - `labs/lab11/waf/docker-compose.waf.yml`

## Checklist

- [x] Title is clear (`feat(lab11): hardened nginx + WAF sidecar` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab11.md` exists
- [x] Task 1 — TLS 1.3 + 6 security headers (with proof)
- [x] Task 2 — Rate limit + timeouts + cipher hardening + cert-rotation runbook
- [x] Bonus — Coraza/ModSec WAF + OWASP CRS catching a payload Nginx-alone passes