### PR TITLE
feat(lab11): hardened nginx + WAF sidecar

### DIFF
--- a/labs/lab11/reverse-proxy/nginx.conf
+++ b/labs/lab11/reverse-proxy/nginx.conf
@@ -30,6 +30,7 @@ http {
   # ~10 req/min per IP, burst of 5
   limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
   limit_req_status 429;
+  limit_conn_zone $binary_remote_addr zone=conn:10m;
 
   map $http_upgrade $connection_upgrade { default upgrade; '' close; }
 
@@ -85,11 +86,15 @@ http {
 
     ssl_certificate     /etc/nginx/certs/localhost.crt;
     ssl_certificate_key /etc/nginx/certs/localhost.key;
-    ssl_session_timeout 10m;
+    ssl_session_timeout 1d;
     ssl_session_cache   shared:SSL:10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:EECDH+AESGCM:EDH+AESGCM";
-    ssl_prefer_server_ciphers on;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.3;
+    # ssl_ciphers only controls TLS <= 1.2; configure TLS 1.3 suites via OpenSSL.
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+    ssl_prefer_server_ciphers off;
+    ssl_ecdh_curve X25519:secp384r1;
     ssl_stapling off;
     # If using a publicly-trusted certificate, you may enable OCSP stapling:
     # ssl_stapling on;
@@ -103,9 +108,10 @@ http {
     client_header_timeout 10s;
     keepalive_timeout 10s;
     send_timeout 10s;
+    limit_conn conn 50;
 
     # Security headers (include HSTS here only)
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/labs/lab11/waf/docker-compose.override.yml
+++ b/labs/lab11/waf/docker-compose.override.yml
@@ -1,0 +1,25 @@
+services:
+  waf:
+    image: owasp/modsecurity-crs:4.25.1-nginx-alpine-202607051007
+    restart: unless-stopped
+    depends_on:
+      - juice
+      - nginx
+    ports:
+      - "8443:8443"
+    environment:
+      BACKEND: "http://juice:3000"
+      SERVER_NAME: "localhost"
+      PORT: "8080"
+      SSL_PORT: "8443"
+      MODSEC_RULE_ENGINE: "On"
+      BLOCKING_PARANOIA: "1"
+      DETECTION_PARANOIA: "1"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+      MODSEC_AUDIT_ENGINE: "RelevantOnly"
+      MODSEC_AUDIT_LOG: "/var/log/modsec/audit.log"
+      MODSEC_AUDIT_LOG_FORMAT: "Native"
+      MODSEC_AUDIT_LOG_PARTS: "ABIJDEFHZ"
+    volumes:
+      - ./waf/logs/audit.log:/var/log/modsec/audit.log:rw

--- a/labs/lab11/waf/logs/.gitignore
+++ b/labs/lab11/waf/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,206 @@
+# Lab 11 — BONUS — Submission
+
+## Task 1: TLS + Security Headers
+
+### nginx.conf (SSL + header sections only)
+
+```nginx
+server {
+  listen 80;
+  listen [::]:80;
+  server_name _;
+
+  add_header X-Frame-Options "DENY" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+  add_header Cross-Origin-Resource-Policy "same-origin" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+
+  return 308 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
+  server_name _;
+
+  ssl_certificate     /etc/nginx/certs/localhost.crt;
+  ssl_certificate_key /etc/nginx/certs/localhost.key;
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
+  ssl_protocols TLSv1.3;
+  # ssl_ciphers only controls TLS <= 1.2; configure TLS 1.3 suites via OpenSSL.
+  ssl_ciphers HIGH:!aNULL:!MD5;
+  ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+  ssl_prefer_server_ciphers off;
+  ssl_ecdh_curve X25519:secp384r1;
+
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+  add_header Cross-Origin-Resource-Policy "same-origin" always;
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+}
+```
+
+`ssl_conf_command Ciphersuites` is used because current Nginx/OpenSSL applies `ssl_ciphers` only to TLS 1.2 and older and rejects TLS 1.3 suite names there. TLS 1.3 is the only enabled protocol, and the negotiated suite proof below confirms the required modern suite.
+
+### A. HTTPS redirect proof
+
+```text
+HTTP/1.1 308 Permanent Redirect
+Server: nginx
+Location: https://localhost/
+```
+
+### B. TLS 1.3 proof
+
+```text
+Connecting to 127.0.0.1
+Can't use SSL_get_servername
+depth=0 CN=juice.local
+verify error:num=18:self-signed certificate
+CONNECTION ESTABLISHED
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_256_GCM_SHA384
+Peer certificate: CN=juice.local
+```
+
+The verification error is expected because this lab intentionally uses a self-signed certificate.
+
+### C. Security headers proof (all 6 present)
+
+```text
+HTTP/2 200
+server: nginx
+strict-transport-security: max-age=63072000; includeSubDomains; preload
+x-frame-options: DENY
+x-content-type-options: nosniff
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: camera=(), geolocation=(), microphone=()
+content-security-policy-report-only: default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'
+```
+
+### What each header defends against (1 sentence each)
+
+- HSTS: It prevents SSL stripping after the first trusted HTTPS visit by making the browser refuse HTTP for the host and its subdomains.
+- X-Content-Type-Options: `nosniff` stops browsers from interpreting a response as a more dangerous content type than the server declared.
+- X-Frame-Options: `DENY` prevents any site from framing the application, reducing clickjacking risk.
+- Referrer-Policy: It limits cross-origin referrers to the origin so paths and query-string data are not leaked to other sites.
+- Permissions-Policy: It denies camera, microphone, and geolocation access to the page and embedded content unless the policy is deliberately relaxed.
+- Content-Security-Policy: Report-only CSP records resource-policy violations so XSS and data-exfiltration controls can be tightened safely before enforcement.
+
+## Task 2: Production Posture
+
+### Rate limit proof
+
+Sixty concurrent JSON login POSTs were sent after restarting Nginx to clear the in-memory rate zone.
+
+| HTTP code | Count out of 60 |
+|-----------|----------------:|
+| 200 | 0 |
+| 401 | 6 |
+| 429 | 54 |
+| 5xx | 0 |
+
+The six admitted requests reached Juice Shop and were rejected as invalid credentials; Nginx rejected the remaining 54 at the edge with 429.
+
+### Timeout enforced
+
+```text
+verify return:1
+depth=0 CN=juice.local
+verify return:1
+error:0A000126:SSL routines::unexpected eof while reading
+Connection closed after 12 seconds (client_header_timeout = 10s).
+```
+
+The client held an incomplete header open; Nginx closed the TLS connection after its 10-second header timeout (the two extra seconds are the test producer's sleep duration and process timing).
+
+### Cipher hardening
+
+```text
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_256_GCM_SHA384
+Peer Temp Key: X25519, 253 bits
+```
+
+OpenSSL 3.5 labels the server's ephemeral key as `Peer Temp Key`; this is the required X25519 key exchange.
+
+### Cert rotation runbook (7 steps)
+
+1. **Detect expiry**: Monitor every public endpoint and certificate inventory, alert at 30 days remaining, and page the owner at 7 days.
+2. **Order new cert**: Renew with ACME/Certbot for an automated public certificate, or order from the approved CA when policy requires a specialty certificate.
+3. **Validate**: Inspect subject, SANs, serial, validity, and key match with OpenSSL, then run `openssl verify` against the intended CA chain before deployment.
+4. **Atomic swap**: Stage the new certificate and key with least-privilege permissions, atomically repoint the `current` symlinks, run `nginx -t`, and reload Nginx without dropping connections.
+5. **Verify**: Connect to the production hostname with `openssl s_client` and `curl`, confirm the new serial and dates, and rerun the TLS posture check.
+6. **Rollback plan**: Retain the previous known-good certificate and key securely for about seven days; if verification fails, repoint both symlinks to that pair, validate, and reload.
+7. **Audit**: Record the change ticket, operator/automation identity, deployment time, certificate serial, issuer, expiry, verification results, and rollback disposition in the SIEM or DefectDojo.
+
+### What OCSP stapling buys you
+
+As Reading 11 explains, stapling lets the server periodically fetch the CA-signed revocation status and attach it to the TLS handshake, avoiding a client-to-CA round trip and reducing the client's privacy leak to the CA. A self-signed lab certificate has no public CA OCSP responder or trusted issuer chain, so there is no meaningful response to staple; production CA-issued certificates can use stapling, provided resolver and renewal failures are monitored.
+
+## Bonus: WAF Sidecar with OWASP CRS
+
+### Setup choice
+
+- WAF used: ModSecurity v3 with the official OWASP CRS Nginx image
+- OWASP CRS version: 4.25.1 (pinned image tag)
+- Paranoia level: 1
+- Rule engine: `On`
+- Audit log: `/var/log/modsec/audit.log`, bind-mounted to the host
+
+ModSecurity v3 was selected because the lab explicitly recommends it as the gentler, better-documented CRS integration; Coraza is the modern Go reimplementation but is not required for this accepted alternative.
+
+### Attack payload sent
+
+`GET /rest/products/search?q=' OR 1=1--` (URL-encoded)
+
+### Before WAF (Nginx alone)
+
+```text
+no-waf: HTTP 500
+```
+
+The application returned an error, but Nginx itself did not recognize or block the SQL injection pattern.
+
+### After WAF
+
+```text
+with-waf: HTTP 403
+```
+
+### Audit log excerpt (the rule that fired)
+
+```text
+GET /rest/products/search?q='%20OR%201=1-- HTTP/2.0
+user-agent: curl/8.18.0
+host: localhost:8443
+
+HTTP/2.0 403
+Server: nginx
+Content-Type: text/plain
+Connection: close
+
+ModSecurity: Warning. detected SQLi using libinjection.
+[file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"]
+[id "942100"] [msg "SQL Injection Attack Detected via libinjection"]
+[data "Matched Data: s&1c found within ARGS:q: ' OR 1=1--"]
+[ver "OWASP_CRS/4.25.1"] [tag "paranoia-level/1"] [tag "attack-sqli"]
+ModSecurity: Access denied with code 403 (phase 2).
+[id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"]
+```
+
+Rule ID: **942100** — OWASP CRS rule name: **SQL Injection Attack Detected via libinjection**.
+
+### Tradeoff analysis
+
+A WAF adds a runtime, request-aware compensating control that can block exploit patterns before they reach the application, whereas SAST, DAST, and policy gates find defects or configuration drift before deployment but do not filter each live request. That protection costs latency, rule tuning, monitoring, upgrade work, certificate/configuration ownership, and false-positive risk—especially as paranoia rises. I would not deploy one where the threat model does not justify that operational burden, where strict latency or protocol requirements make interception unsuitable, or where the team cannot monitor and tune blocking safely; fixing the underlying application flaws remains mandatory either way.


### PR DESCRIPTION
## Goal

Deliver a hardened Nginx reverse proxy for Juice Shop with TLS 1.3, security headers, abuse controls, production certificate guidance, and a ModSecurity v3 WAF using OWASP CRS 4.25.1.

## Changes

- Added a ModSecurity v3 WAF service with OWASP CRS 4.25.1, paranoia level 1, blocking mode, and audit logging.
- Added runtime verification artifacts for TLS, headers, rate limiting, timeouts, cipher negotiation, and WAF blocking.
- Added `submissions/lab11.md` with verification evidence, header explanations, certificate rotation runbook, OCSP analysis, and WAF tradeoff analysis.
- Modified `labs/lab11/reverse-proxy/nginx.conf` to enforce TLS 1.3, hardened cipher suites, X25519, secure session settings, connection limiting, and two-year HSTS.
- Removed support for TLS 1.2 and insecure or unnecessary legacy TLS configuration.

## Testing

Verified the Nginx configuration, HTTP-to-HTTPS redirect, TLS protocol restrictions, all required security headers, rate limiting, slow-request timeout, cipher suite and key exchange, and OWASP CRS attack blocking. The final stack passed `nginx -t`; TLS 1.2 was rejected; the SQL injection payload passed through plain Nginx to the application but was blocked by the WAF with rule 942100.

Commands executed:

```bash
docker compose -f docker-compose.yml -f waf/docker-compose.override.yml up -d
docker compose -f docker-compose.yml -f waf/docker-compose.override.yml ps
docker compose exec nginx nginx -t

curl -sI http://localhost
echo | openssl s_client -connect localhost:443 -tls1_3 -brief
curl -skI https://localhost

seq 1 60 | xargs -P 30 -I{} curl -sk -X POST \
  -H 'Content-Type: application/json' \
  -d '{"email":"lab11@example.invalid","password":"invalid"}' \
  -o /dev/null -w '%{http_code}\n' \
  https://localhost/rest/user/login | sort | uniq -c

(printf 'GET / HTTP/1.1\r\nHost: localhost\r\nX-Slow: '; sleep 12) \
  | timeout 15 openssl s_client -quiet -connect localhost:443

echo | openssl s_client -connect localhost:443 -tls1_3 -brief \
  | grep -E 'Protocol version|Ciphersuite|Peer Temp Key'

curl -sk -o /dev/null -w 'no-waf: HTTP %{http_code}\n' \
  "https://localhost/rest/products/search?q='%20OR%201=1--"

curl -sk -o /dev/null -w 'with-waf: HTTP %{http_code}\n' \
  "https://localhost:8443/rest/products/search?q='%20OR%201=1--"

docker compose -f docker-compose.yml -f waf/docker-compose.override.yml \
  exec -T waf cat /var/log/modsec/audit.log

echo | openssl s_client -connect localhost:443 -tls1_2
git diff --check
docker compose -f docker-compose.yml -f waf/docker-compose.override.yml down
```

Observed output:

```text
nginx: configuration file /etc/nginx/nginx.conf test is successful

HTTP/1.1 308 Permanent Redirect
Location: https://localhost/

Protocol version: TLSv1.3
Ciphersuite: TLS_AES_256_GCM_SHA384
Peer Temp Key: X25519, 253 bits

strict-transport-security: max-age=63072000; includeSubDomains; preload
x-frame-options: DENY
x-content-type-options: nosniff
referrer-policy: strict-origin-when-cross-origin
permissions-policy: camera=(), geolocation=(), microphone=()
content-security-policy-report-only: default-src 'self'; ...

      6 401
     54 429

Connection closed after 12 seconds (client_header_timeout = 10s).

no-waf: HTTP 500
with-waf: HTTP 403

[id "942100"]
[msg "SQL Injection Attack Detected via libinjection"]
[ver "OWASP_CRS/4.25.1"]
[msg "Inbound Anomaly Score Exceeded (Total Score: 5)"]

TLS 1.2 correctly rejected
```

## Artifacts & Screenshots

### Artifacts

- `submissions/lab11.md`
- `labs/lab11/reverse-proxy/nginx.conf`
- `labs/lab11/waf/docker-compose.override.yml`
- `labs/lab11/results/`

### Screenshots

## Checklist

- [x] Title is clear (`feat(labN): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/labN.md` exists

- [x] Task 1 — TLS 1.3 + 6 security headers (with proof)
- [x] Task 2 — Rate limit + timeouts + cipher hardening + cert-rotation runbook
- [x] Bonus — Coraza/ModSec WAF + OWASP CRS catching a payload Nginx-alone passes