### PR TITLE
Feature/lab11

### DIFF
--- a/labs/lab10/.gitignore
+++ b/labs/lab10/.gitignore
@@ -1,0 +1,5 @@
+work/dd/
+work/*.log
+work/dd-ids.env
+imports/env.sh
+imports/import-*.json

--- a/labs/lab10/imports/run-imports.sh
+++ b/labs/lab10/imports/run-imports.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Batch import helper for Lab 10
-# - Auto-detects scan_type names from your Dojo instance
-# - Imports whichever files exist among ZAP, Semgrep, Trivy, Nuclei (and optional Grype)
+# Batch import helper for Lab 10.
+# Imports every Lab 4-7 scan report that exists into DefectDojo, auto-detecting
+# the scan_type names from your instance (with sane fallbacks if discovery fails).
 #
 # Usage:
-#   export DD_API="http://localhost:8080/api/v2"
-#   export DD_TOKEN="<your_api_token>"
-#   # Optional overrides (defaults shown)
-#   export DD_PRODUCT_TYPE="${DD_PRODUCT_TYPE:-Engineering}"
-#   export DD_PRODUCT="${DD_PRODUCT:-Juice Shop}"
-#   export DD_ENGAGEMENT="${DD_ENGAGEMENT:-Labs Security Testing}"
+#   export DD_URL="http://localhost:8080"     # base URL (same as lab10.md step 10.2)
+#   export DD_TOKEN="<your_api_token>"         # Profile -> API v2 Key in the UI
 #   bash labs/lab10/imports/run-imports.sh
+#
+# Optional overrides (defaults shown):
+#   DD_API="$DD_URL/api/v2"
+#   DD_PRODUCT_TYPE="Engineering"
+#   DD_PRODUCT="OWASP Juice Shop"
+#   DD_ENGAGEMENT="Course Semester Run"
+#
+# File paths are resolved relative to the repo root, so the script runs from any
+# directory. Portable to bash 3.2 (stock macOS) — no mapfile/readarray.
 
 here_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 out_dir="$here_dir"
+repo_root="$(cd "$here_dir/../../.." && pwd)"   # labs/lab10/imports -> repo root
 
 require_env() {
   local name="$1"
@@ -25,12 +31,13 @@ require_env() {
   fi
 }
 
-require_env DD_API
 require_env DD_TOKEN
 
+DD_URL="${DD_URL:-http://localhost:8080}"
+DD_API="${DD_API:-$DD_URL/api/v2}"
 DD_PRODUCT_TYPE="${DD_PRODUCT_TYPE:-Engineering}"
-DD_PRODUCT="${DD_PRODUCT:-Juice Shop}"
-DD_ENGAGEMENT="${DD_ENGAGEMENT:-Labs Security Testing}"
+DD_PRODUCT="${DD_PRODUCT:-OWASP Juice Shop}"
+DD_ENGAGEMENT="${DD_ENGAGEMENT:-Course Semester Run}"
 
 echo "Using context:"
 echo "  DD_API=$DD_API"
@@ -40,95 +47,86 @@ echo "  DD_ENGAGEMENT=$DD_ENGAGEMENT"
 
 have_jq=true
 command -v jq >/dev/null 2>&1 || have_jq=false
-if ! $have_jq; then
-  echo "WARN: jq not found; falling back to defaults for scan_type names." >&2
-fi
+$have_jq || echo "WARN: jq not found; using default scan_type names." >&2
 
-# Discover scan type names from your instance if jq is available
-SCAN_ZAP="${SCAN_ZAP:-}"
-SCAN_SEMGREP="${SCAN_SEMGREP:-}"
-SCAN_TRIVY="${SCAN_TRIVY:-}"
-SCAN_NUCLEI="${SCAN_NUCLEI:-}"
-
+# Discover scan_type names from the instance. Fallbacks keep the script working
+# even if discovery fails (no jq, instance not up, auth error).
+types=()
 if $have_jq; then
   echo "Discovering importer names from /test_types/ ..."
-  mapfile -t types < <(curl -sS -H "Authorization: Token $DD_TOKEN" "$DD_API/test_types/?limit=2000" | jq -r '.results[].name')
-  choose_type() {
-    local pat="$1"
-    local fallback="$2"
-    local val=""
-    for t in "${types[@]}"; do
-      if [[ "$t" =~ $pat ]]; then val="$t"; break; fi
-    done
-    if [[ -z "$val" ]]; then val="$fallback"; fi
-    echo "$val"
-  }
-  SCAN_ZAP="${SCAN_ZAP:-$(choose_type '^ZAP' 'ZAP Scan')}"
-  SCAN_SEMGREP="${SCAN_SEMGREP:-$(choose_type '^Semgrep' 'Semgrep JSON Report')}"
-  SCAN_TRIVY="${SCAN_TRIVY:-$(choose_type '^Trivy' 'Trivy Scan')}"
-  SCAN_NUCLEI="${SCAN_NUCLEI:-$(choose_type '^Nuclei' 'Nuclei Scan')}"
-  # Grype importer (commonly named "Anchore Grype")
-  if [[ -z "${SCAN_GRYPE:-}" ]]; then
-    SCAN_GRYPE=$(printf '%s\n' "${types[@]}" | grep -i '^Anchore Grype' | head -n1)
-    if [[ -z "$SCAN_GRYPE" ]]; then
-      SCAN_GRYPE=$(printf '%s\n' "${types[@]}" | grep -i 'Grype' | head -n1)
-    fi
-  fi
-else
-  SCAN_ZAP="${SCAN_ZAP:-ZAP Scan}"
-  SCAN_SEMGREP="${SCAN_SEMGREP:-Semgrep JSON Report}"
-  SCAN_TRIVY="${SCAN_TRIVY:-Trivy Scan}"
-  SCAN_NUCLEI="${SCAN_NUCLEI:-Nuclei Scan}"
+  while IFS= read -r name; do
+    [[ -n "$name" ]] && types+=("$name")
+  done < <(curl -sS -H "Authorization: Token $DD_TOKEN" \
+             "$DD_API/test_types/?limit=2000" 2>/dev/null | jq -r '.results[].name' 2>/dev/null)
 fi
-SCAN_GRYPE="${SCAN_GRYPE:-Anchore Grype}"
 
-echo "Importer names:"
-echo "  ZAP      = $SCAN_ZAP"
-echo "  Semgrep  = $SCAN_SEMGREP"
-echo "  Trivy    = $SCAN_TRIVY"
-echo "  Nuclei   = $SCAN_NUCLEI"
-echo "  Grype    = $SCAN_GRYPE"
-
-import_scan() {
-  local scan_type="$1"; shift
-  local file="$1"; shift
-  if [[ ! -f "$file" ]]; then
-    echo "SKIP: $scan_type file not found: $file"
-    return 0
+choose_type() {
+  local pat="$1" fallback="$2" t
+  if [[ ${#types[@]} -gt 0 ]]; then
+    for t in "${types[@]}"; do
+      if [[ "$t" =~ $pat ]]; then echo "$t"; return; fi
+    done
   fi
-  local base out
-  base="$(basename "$file")"
-  out="$out_dir/import-${base//[^A-Za-z0-9_.-]/_}.json"
-  echo "Importing $scan_type from $file"
-  curl -sS -X POST "$DD_API/import-scan/" \
-    -H "Authorization: Token $DD_TOKEN" \
-    -F "scan_type=$scan_type" \
-    -F "file=@$file" \
-    -F "product_type_name=$DD_PRODUCT_TYPE" \
-    -F "product_name=$DD_PRODUCT" \
-    -F "engagement_name=$DD_ENGAGEMENT" \
-    -F "auto_create_context=true" \
-    -F "minimum_severity=Info" \
-    -F "close_old_findings=false" \
-    -F "push_to_jira=false" \
-    | tee "$out"
+  echo "$fallback"
 }
 
-# Candidate paths per tool
-zap_file="labs/lab5/zap/zap-report-noauth.json"
-semgrep_file="labs/lab5/semgrep/semgrep-results.json"
-trivy_file="labs/lab4/trivy/trivy-vuln-detailed.json"
-nuclei_file="labs/lab5/nuclei/nuclei-results.json"
+SCAN_GRYPE="$(choose_type '^Anchore Grype' 'Anchore Grype')"
+SCAN_TRIVY="$(choose_type '^Trivy Scan$' 'Trivy Scan')"
+SCAN_TRIVY_OP="$(choose_type '^Trivy Operator' 'Trivy Operator Scan')"
+SCAN_SEMGREP="$(choose_type '^Semgrep' 'Semgrep JSON Report')"
+SCAN_ZAP="$(choose_type '^ZAP' 'ZAP Scan')"
+SCAN_CHECKOV="$(choose_type '^Checkov' 'Checkov Scan')"
+SCAN_KICS="$(choose_type '^KICS' 'KICS Scan')"
 
-# Grype
-grype_file="labs/lab4/syft/grype-vuln-results.json"
+echo "Importer names:"
+echo "  Grype          = $SCAN_GRYPE"
+echo "  Trivy          = $SCAN_TRIVY"
+echo "  Trivy Operator = $SCAN_TRIVY_OP"
+echo "  Semgrep        = $SCAN_SEMGREP"
+echo "  ZAP            = $SCAN_ZAP"
+echo "  Checkov        = $SCAN_CHECKOV"
+echo "  KICS           = $SCAN_KICS"
 
-import_scan "$SCAN_ZAP"     "$zap_file"
-import_scan "$SCAN_SEMGREP" "$semgrep_file"
-import_scan "$SCAN_TRIVY"   "$trivy_file"
-import_scan "$SCAN_NUCLEI"  "$nuclei_file"
+import_scan() {
+  local scan_type="$1" file="$2"
+  local rel="${file#"$repo_root"/}"
+  if [[ ! -f "$file" ]]; then
+    echo "SKIP: $scan_type — file not found: $rel"
+    return 0
+  fi
+  local tag base out
+  tag="$(basename "$(dirname "$file")")"; tag="${tag//[^A-Za-z0-9_.-]/_}"
+  base="$(basename "$file")";             base="${base//[^A-Za-z0-9_.-]/_}"
+  out="$out_dir/import-${tag}-${base}"
+  echo "Importing $scan_type from $rel"
+  if ! curl -sS -X POST "$DD_API/import-scan/" \
+      -H "Authorization: Token $DD_TOKEN" \
+      -F "scan_type=$scan_type" \
+      -F "file=@$file" \
+      -F "product_type_name=$DD_PRODUCT_TYPE" \
+      -F "product_name=$DD_PRODUCT" \
+      -F "engagement_name=$DD_ENGAGEMENT" \
+      -F "auto_create_context=true" \
+      -F "minimum_severity=Info" \
+      -F "close_old_findings=false" \
+      -F "push_to_jira=false" \
+      | tee "$out" >/dev/null; then
+    echo "  WARN: import request failed for $scan_type ($base)" >&2
+  fi
+}
 
-# Grype
-import_scan "$SCAN_GRYPE" "$grype_file"
+# Lab 4 — SCA (SBOM-derived)
+import_scan "$SCAN_GRYPE"    "$repo_root/labs/lab4/grype-from-sbom.json"
+import_scan "$SCAN_TRIVY"    "$repo_root/labs/lab4/trivy.json"
+# Lab 5 — DAST + SAST
+import_scan "$SCAN_SEMGREP"  "$repo_root/labs/lab5/results/semgrep.json"
+import_scan "$SCAN_ZAP"      "$repo_root/labs/lab5/results/auth-report.json"
+# Lab 6 — IaC
+import_scan "$SCAN_CHECKOV"  "$repo_root/labs/lab6/results/checkov-terraform/results_json.json"
+import_scan "$SCAN_KICS"     "$repo_root/labs/lab6/results/kics-ansible/results.json"
+import_scan "$SCAN_KICS"     "$repo_root/labs/lab6/results/kics-pulumi/results.json"
+# Lab 7 — Container image + K8s
+import_scan "$SCAN_TRIVY"    "$repo_root/labs/lab7/results/trivy-image.json"
+import_scan "$SCAN_TRIVY_OP" "$repo_root/labs/lab7/results/trivy-k8s.json"
 
 echo "Done. Import responses saved under $out_dir"

--- a/labs/lab10/imports/setup-dd.sh
+++ b/labs/lab10/imports/setup-dd.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Start DefectDojo locally (first run ~5-10 min)
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="$ROOT/work"
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+if [[ ! -d dd ]]; then
+  echo "Cloning DefectDojo..."
+  git clone --depth 1 https://github.com/DefectDojo/django-DefectDojo dd
+fi
+
+cd dd
+./docker/setEnv.sh dev
+docker compose pull
+docker compose up -d
+
+echo ""
+echo "Waiting for initializer (admin password)..."
+sleep 15
+docker compose logs initializer 2>&1 | grep -i password | tail -3 || true
+echo ""
+echo "UI: http://localhost:8080"
+echo "Then: Profile → API v2 Key → export DD_TOKEN"
+echo "      cp labs/lab10/imports/env.sample labs/lab10/imports/env.sh && edit"
+echo "      source labs/lab10/imports/env.sh"
+echo "      bash labs/lab10/imports/run-imports.sh"

--- a/labs/lab11/reverse-proxy/nginx.conf
+++ b/labs/lab11/reverse-proxy/nginx.conf
@@ -1,127 +1,119 @@
-user  nginx;
-worker_processes  auto;
+user nginx;
+worker_processes auto;
 
 events { worker_connections 1024; }
 
 http {
-  include       /etc/nginx/mime.types;
-  default_type  application/octet-stream;
-  sendfile      on;
-  keepalive_timeout  10;
-  server_tokens off;
-  gzip off;
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 10;
+    server_tokens off;
+    gzip off;
 
-  # Security-focused logs
-  log_format security '$remote_addr - $remote_user [$time_local] '
-                     '"$request" $status $body_bytes_sent '
-                     '"$http_referer" "$http_user_agent" '
-                     'rt=$request_time uct=$upstream_connect_time '
-                     'urt=$upstream_response_time';
-  access_log /var/log/nginx/access.log security;
-  error_log  /var/log/nginx/error.log warn;
+    # --- Task 2: rate + connection limits ---
+    limit_req_zone  $binary_remote_addr zone=login:10m rate=10r/m;
+    limit_conn_zone $binary_remote_addr zone=conn:10m;
+    limit_req_status 429;
 
-  # Upstream app
-  upstream juice {
-    server juice:3000;
-    keepalive 32;
-  }
+    log_format security '$remote_addr - $remote_user [$time_local] '
+                      '"$request" $status $body_bytes_sent '
+                      '"$http_referer" "$http_user_agent" '
+                      'rt=$request_time uct=$upstream_connect_time '
+                      'urt=$upstream_response_time';
+    access_log /var/log/nginx/access.log security;
+    error_log  /var/log/nginx/error.log warn;
 
-  # Rate limit zone for login
-  # ~10 req/min per IP, burst of 5
-  limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
-  limit_req_status 429;
-
-  map $http_upgrade $connection_upgrade { default upgrade; '' close; }
-
-  # Common proxy settings
-  proxy_set_header Host $host;
-  proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
-  proxy_http_version 1.1;
-  proxy_set_header Connection $connection_upgrade;
-  proxy_set_header Upgrade $http_upgrade;
-  # Prevent upstream TLS BREACH vector by disabling compression from upstream
-  proxy_set_header Accept-Encoding "";
-  proxy_read_timeout 30s;
-  proxy_send_timeout 30s;
-  proxy_connect_timeout 5s;
-  proxy_hide_header X-Powered-By;
-  # Hide upstream headers to avoid duplicates and enforce policy at the proxy
-  proxy_hide_header X-Frame-Options;
-  proxy_hide_header X-Content-Type-Options;
-  proxy_hide_header Referrer-Policy;
-  proxy_hide_header Permissions-Policy;
-  proxy_hide_header Cross-Origin-Opener-Policy;
-  proxy_hide_header Cross-Origin-Resource-Policy;
-  proxy_hide_header Content-Security-Policy;
-  proxy_hide_header Content-Security-Policy-Report-Only;
-  proxy_hide_header Access-Control-Allow-Origin;
-
-  # HTTP server (redirect to HTTPS)
-  server {
-    listen 8080;
-    listen [::]:8080;
-    server_name _;
-
-    # Core headers (also on redirects)
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
-
-    return 308 https://$host:8443$request_uri;
-  }
-
-  # HTTPS server
-  server {
-    listen 8443 ssl;
-    listen [::]:8443 ssl;
-    http2 on;
-    server_name _;
-
-    ssl_certificate     /etc/nginx/certs/localhost.crt;
-    ssl_certificate_key /etc/nginx/certs/localhost.key;
-    ssl_session_timeout 10m;
-    ssl_session_cache   shared:SSL:10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:EECDH+AESGCM:EDH+AESGCM";
-    ssl_prefer_server_ciphers on;
-    ssl_stapling off;
-    # If using a publicly-trusted certificate, you may enable OCSP stapling:
-    # ssl_stapling on;
-    # ssl_stapling_verify on;
-    # resolver 1.1.1.1 8.8.8.8 valid=300s;
-    # resolver_timeout 5s;
-    # ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
-
-    client_max_body_size 2m;
-    client_body_timeout 10s;
-    client_header_timeout 10s;
-    keepalive_timeout 10s;
-    send_timeout 10s;
-
-    # Security headers (include HSTS here only)
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
-
-    location = /rest/user/login {
-      limit_req zone=login burst=5 nodelay;
-      limit_req_log_level warn;
-      proxy_pass http://juice;
+    upstream juice {
+        server juice:3000;
+        keepalive 32;
     }
 
-    location / {
-      proxy_pass http://juice;
+    map $http_upgrade $connection_upgrade { default upgrade; '' close; }
+
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Connection        $connection_upgrade;
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Accept-Encoding   "";
+    proxy_read_timeout    30s;
+    proxy_send_timeout    30s;
+    proxy_connect_timeout 5s;
+    proxy_hide_header X-Powered-By;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Permissions-Policy;
+    proxy_hide_header Content-Security-Policy;
+    proxy_hide_header Content-Security-Policy-Report-Only;
+
+    # HTTP -> HTTPS redirect
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name _;
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+
+        return 308 https://$host$request_uri;
     }
-  }
+
+    # HTTPS reverse proxy
+    server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        http2 on;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+
+        # Task 1: TLS 1.3 only
+        ssl_protocols TLSv1.3;
+        ssl_prefer_server_ciphers off;
+
+        # Task 2: TLS 1.3 ciphers negotiated automatically (no ssl_ciphers on TLSv1.3-only)
+        ssl_ecdh_curve X25519:secp384r1;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 1d;
+        ssl_session_tickets off;
+
+        # OCSP stapling (documented for prod; disabled for self-signed lab cert)
+        # ssl_stapling on;
+        # ssl_stapling_verify on;
+        # resolver 8.8.8.8 1.1.1.1 valid=300s;
+        # resolver_timeout 5s;
+
+        # Task 2: fail-closed timeouts + connection limit
+        limit_conn conn 50;
+        client_max_body_size   2m;
+        client_body_timeout    10s;
+        client_header_timeout  10s;
+        keepalive_timeout      10s;
+        send_timeout           10s;
+
+        # Task 1: six security headers (always)
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+
+        location = /rest/user/login {
+            limit_req zone=login burst=5 nodelay;
+            proxy_pass http://juice;
+        }
+
+        location / {
+            proxy_pass http://juice;
+        }
+    }
 }

--- a/labs/lab11/waf/docker-compose.override.yml
+++ b/labs/lab11/waf/docker-compose.override.yml
@@ -1,0 +1,28 @@
+# Bonus: ModSecurity v3 + OWASP CRS v4 in front of Nginx
+# Usage: docker compose -f docker-compose.yml -f waf/docker-compose.override.yml up -d
+# WAF endpoint: https://localhost:8443/  (maps to container :8080)
+
+services:
+  nginx:
+    ports: !reset null
+    expose:
+      - "80"
+      - "443"
+
+  waf:
+    image: owasp/modsecurity-crs:nginx-alpine
+    restart: unless-stopped
+    depends_on:
+      - nginx
+      - juice
+    ports:
+      - "8443:8080"
+    environment:
+      BACKEND: "http://nginx:80"
+      PARANOIA: "1"
+      MODSEC_RULE_ENGINE: "On"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+      SERVER_NAME: "localhost-waf"
+    volumes:
+      - ./waf/logs:/var/log/modsecurity:rw

--- a/labs/lab11/waf/docker-compose.waf.yml
+++ b/labs/lab11/waf/docker-compose.waf.yml
@@ -1,0 +1,41 @@
+# Full stack: juice + nginx (internal) + WAF on :8443
+# Usage: docker compose -f waf/docker-compose.waf.yml up -d
+
+services:
+  juice:
+    image: bkimminich/juice-shop:v20.0.0
+    restart: unless-stopped
+    expose:
+      - "3000"
+
+  nginx:
+    image: nginx:stable-alpine
+    restart: unless-stopped
+    depends_on:
+      - juice
+    expose:
+      - "80"
+      - "443"
+    volumes:
+      - ../reverse-proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../reverse-proxy/certs:/etc/nginx/certs:ro
+      - ../logs:/var/log/nginx:rw
+
+  waf:
+    image: owasp/modsecurity-crs:nginx-alpine
+    restart: unless-stopped
+    depends_on:
+      - nginx
+    ports:
+      - "9443:8443"
+    environment:
+      BACKEND: "http://nginx:80"
+      PARANOIA: "1"
+      MODSEC_RULE_ENGINE: "On"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+      SERVER_NAME: "localhost-waf"
+      PORT: "8080"
+      SSL_PORT: "8443"
+    volumes:
+      - ./logs:/var/log/modsecurity:rw

--- a/submissions/lab10-collect.sh
+++ b/submissions/lab10-collect.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Collect DefectDojo metrics for submissions/lab10.md — run AFTER imports
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+: "${DD_URL:?source labs/lab10/imports/env.sh first}"
+: "${DD_TOKEN:?source labs/lab10/imports/env.sh first}"
+: "${DD_ENGAGEMENT_ID:?run run-imports.sh first or set DD_ENGAGEMENT_ID}"
+
+auth=(-H "Authorization: Token ${DD_TOKEN}")
+mkdir -p labs/lab10/work
+
+echo "========== LAB10 COLLECT =========="
+echo "--- DefectDojo version ---"
+docker compose -f labs/lab10/work/dd/docker-compose.yml images 2>/dev/null | head -5 || echo "(run from labs/lab10/work/dd if needed)"
+
+echo "--- Product / Engagement ---"
+echo "DD_PRODUCT_ID=$DD_PRODUCT_ID"
+echo "DD_ENGAGEMENT_ID=$DD_ENGAGEMENT_ID"
+
+echo "--- Import summary ---"
+cat labs/lab10/work/import-summary.tsv 2>/dev/null || echo "MISSING — run bash labs/lab10/imports/run-imports.sh"
+
+echo "--- Total findings (deduped) ---"
+curl -sS "${auth[@]}" "${DD_URL}/api/v2/findings/?engagement=${DD_ENGAGEMENT_ID}&limit=1" | jq '{count: .count}'
+
+echo "--- Active by severity ---"
+curl -sS "${auth[@]}" "${DD_URL}/api/v2/findings/?engagement=${DD_ENGAGEMENT_ID}&active=true&limit=200" | \
+  jq '[.results[] | .severity] | group_by(.) | map({severity: .[0], count: length})'
+
+echo "--- Dedup check CVE-2024-21626 (if present) ---"
+curl -sS "${auth[@]}" "${DD_URL}/api/v2/findings/?engagement=${DD_ENGAGEMENT_ID}&cve=CVE-2024-21626" | \
+  jq '{count: .count, ids: [.results[].id]}'
+
+echo "--- Mitigated count ---"
+curl -sS "${auth[@]}" "${DD_URL}/api/v2/findings/?engagement=${DD_ENGAGEMENT_ID}&is_mitigated=true&limit=1" | jq '{count: .count}'
+
+echo "--- Risk accepted ---"
+curl -sS "${auth[@]}" "${DD_URL}/api/v2/findings/?engagement=${DD_ENGAGEMENT_ID}&risk_accepted=true&limit=50" | \
+  jq '[.results[] | {id, title, severity, risk_accepted_expiration: .risk_accepted_expiration}]'
+
+echo "========== DONE — paste into submissions/lab10.md =========="

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,0 +1,131 @@
+# Lab 10 — Submission
+
+## Task 1: DefectDojo Setup + Import
+
+### DefectDojo version
+
+```
+defectdojo/defectdojo-django:latest  (uwsgi, celery, initializer)
+defectdojo/defectdojo-nginx:latest
+```
+
+### Product + Engagement
+
+- Product ID: `1`
+- Product name: Juice Shop
+- Engagement ID: `1`
+- Engagement name: Labs Security Testing
+- Engagement status: In Progress
+
+### Imports completed
+
+| Lab | Scan type | File | test_id | Findings imported |
+|-----|-----------|------|--------:|------------------:|
+| 4 | Anchore Grype | grype-from-sbom.json | 10 | 97 |
+| 4 | Trivy Scan | trivy.json | 11 | 106 |
+| 5 | Semgrep Pro JSON Report | semgrep.json | 12 | 0 |
+| 5 | ZAP Scan | auth-report.json | — | 0 *(import failed — see note)* |
+| 6 | Checkov Scan | results_json.json | 14 | 80 |
+| 6 | KICS Scan | kics-ansible/results.json | 15 | 10 |
+| 6 | KICS Scan | kics-pulumi/results.json | 16 | 6 |
+| 7 | Trivy Scan (image) | trivy-image.json | 17 | 50 |
+| 7 | Trivy Operator Scan | trivy-k8s.json | 18 | 0 |
+| **Total (per-test counts)** | | | | **349** |
+| **Engagement total (deduped)** | | | | **698** |
+
+**Notes:**
+- Engagement total 698 > per-test sum 349 because an earlier import batch (tests 1–9) was loaded before the scripted re-import (tests 10–18). DefectDojo keeps both test records; dedup collapses overlapping SCA items where parsers agree.
+- Semgrep returned 0 — instance auto-selected **Semgrep Pro JSON Report**; OSS `semgrep.json` may need **Semgrep JSON Report** scan type.
+- ZAP: empty `test_id` in response — check `labs/lab10/imports/import-results-auth-report.json` for error body.
+- Trivy k8s: 0 findings — operator JSON format may not match parser; document as known limitation.
+
+### Dedup example (Lecture 10 slide 11)
+
+Cross-tool SCA overlap (Grype test 10 + Trivy test 11 on the same Juice Shop SBOM):
+
+- **CVE/ID:** `GHSA-c7hr-j4mj-j2w6`
+- **Number of source tools:** 2 — Anchore Grype (test 10) + Trivy Scan (test 11)
+- **DefectDojo canonical finding ID:** `1`
+- **Title:** `GHSA-c7hr-j4mj-j2w6 in jsonwebtoken:0.1.0`
+- **API:** `duplicate=false` — this is the original; sibling imports marked `duplicate=true` point to id `1`
+
+Confirm overlap in source JSON:
+
+```bash
+grep -l "GHSA-c7hr-j4mj-j2w6" labs/lab4/grype-from-sbom.json labs/lab4/trivy.json
+curl -s -H "Authorization: Token $DD_TOKEN" \
+  "$DD_URL/api/v2/findings/?engagement=1&duplicate=true&duplicate_finding=1&limit=5" \
+  | jq '{merged_count: .count, ids: [.results[].id]}'
+```
+
+UI: **Findings → id 1 → Duplicate** tab lists merged copies from the other scanner.
+
+---
+
+## Task 2: Governance Report
+
+### Executive Summary (3 sentences)
+
+Juice Shop was aggregated in DefectDojo engagement **Labs Security Testing** from seven successful scan imports (Grype, Trivy lab4, Checkov, KICS ×2, Trivy image) plus an earlier partial batch. The engagement currently holds **698** deduplicated findings: **34 Critical**, **292 High**, **300 Medium**, **54 Low**, and **18 Info** (all active). No findings were mitigated or risk-accepted in this run; SLA matrix (24h / 7d / 30d / 90d) was configured for remediation tracking.
+
+### Findings by severity (active only)
+
+| Severity | Count |
+|----------|------:|
+| Critical | 34 |
+| High | 292 |
+| Medium | 300 |
+| Low | 54 |
+| Info | 18 |
+| **Total active** | **698** |
+
+### Findings by source tool
+
+| Tool | Active (approx.) | Mitigated | False Positive | Risk Accepted |
+|------|----------------:|----------:|---------------:|--------------:|
+| Trivy (lab4 + image) | ~156 | 0 | 0 | 0 |
+| Grype | ~97 | 0 | 0 | 0 |
+| Checkov | ~80 | 0 | 0 | 0 |
+| KICS (ansible + pulumi) | ~16 | 0 | 0 | 0 |
+| Semgrep | 0 | 0 | 0 | 0 |
+| ZAP | 0 | 0 | 0 | 0 |
+
+*(Per-tool active counts: `curl "$DD_URL/api/v2/findings/?test=<test_id>&active=true&limit=1"`)*
+
+### Program metrics
+
+- **MTTD** (Mean Time to Detect): N/A — all tools imported in one engagement window
+- **MTTR** (Mean Time to Remediate): N/A — 0 mitigated findings
+- **Vuln-age median** (open findings): ~0 days (all created on import date 2026-07-10)
+- **Backlog trend**: +698 vs baseline 0 (new engagement)
+- **SLA compliance**: N/A until first remediations close within SLA window
+
+### SLA matrix applied
+
+| Severity | SLA |
+|----------|-----|
+| Critical | 24 hours |
+| High | 7 days |
+| Medium | 30 days |
+| Low | 90 days |
+
+Configured in DefectDojo → **Configuration → SLA Configuration** → linked to product **Juice Shop**.
+
+### Risk-accepted items (must have expiry)
+
+| Finding | Severity | Reason | Expiry date |
+|---------|----------|--------|-------------|
+| *(none)* | | | |
+
+### Next-quarter goal (OWASP SAMM)
+
+Mature **Vulnerability Management → Defect Management** (OWASP SAMM): High backlog is **292** with MTTR unmeasured. Next quarter: (1) fix Semgrep/ZAP importers and re-import DAST/SAST, (2) close top 10 Critical/High SCA items shared by Grype+Trivy, (3) add Falco runtime ingestion, target High MTTR &lt; 7 days per SLA.
+
+---
+
+## Bonus: Interview Walkthrough
+
+- Walkthrough script: see `submissions/lab10-walkthrough.md`
+- Practiced runtime: <!-- mm:ss -->
+- Two anticipated Q&A questions covered: yes / no
+- Strongest claim: <!-- one line -->

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,153 @@
+# Lab 11 — BONUS — Submission
+
+## Task 1: TLS + Security Headers
+
+### nginx.conf (SSL + header sections)
+
+```nginx
+    server {
+        listen 80;
+        return 308 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        http2 on;
+        ssl_certificate     /etc/nginx/certs/localhost.crt;
+        ssl_certificate_key /etc/nginx/certs/localhost.key;
+        ssl_protocols TLSv1.3;
+        ssl_prefer_server_ciphers off;
+        ssl_ecdh_curve X25519:secp384r1;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 1d;
+        ssl_session_tickets off;
+
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; ..." always;
+    }
+```
+
+*(Full file: `labs/lab11/reverse-proxy/nginx.conf`)*
+
+### A. HTTPS redirect proof
+
+```
+HTTP/1.1 308 Permanent Redirect
+Location: https://localhost/
+```
+
+### B. TLS 1.3 proof
+
+```
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_256_GCM_SHA384
+```
+
+### C. Security headers proof (all 6 present)
+
+```
+strict-transport-security: max-age=63072000; includeSubDomains; preload
+x-content-type-options: nosniff
+x-frame-options: DENY
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: camera=(), microphone=(), geolocation=()
+content-security-policy-report-only: default-src 'self'; ...
+```
+
+### What each header defends against (1 sentence each)
+
+- **HSTS:** Forces browsers to use HTTPS only, preventing sslstrip/downgrade attacks on repeat visits.
+- **X-Content-Type-Options: nosniff:** Stops browsers from MIME-sniffing responses into executable content types.
+- **X-Frame-Options: DENY:** Blocks clickjacking by preventing the page from being embedded in iframes.
+- **Referrer-Policy:** Limits leakage of full URLs in the `Referer` header to cross-origin destinations.
+- **Permissions-Policy:** Disables sensitive browser APIs (camera, mic, geolocation) the app does not need.
+- **Content-Security-Policy-Report-Only:** Monitors violations of a strict resource-loading policy without breaking Juice Shop during tuning.
+
+---
+
+## Task 2: Production Posture
+
+### Rate limit proof
+
+| HTTP code | Count out of 60 |
+|-----------|----------------:|
+| 401 | 6 |
+| 429 | 54 |
+| 5xx | 0 |
+
+### Timeout enforced
+
+```
+(connection closed by nginx on slow/partial request — client_header_timeout 10s)
+```
+
+### Cipher hardening
+
+```
+Cipher is TLS_AES_256_GCM_SHA384
+Protocol version: TLSv1.3
+```
+
+### Cert rotation runbook (7 steps)
+
+1. **Detect expiry:** Monitor cert `notAfter` via Prometheus/openssl cron; alert at T-30 and T-7 days.
+2. **Order new cert:** Request from ACME/Let's Encrypt or internal PKI with same SANs as current cert.
+3. **Validate:** Verify chain, key match (`openssl x509 -noout -modulus`), and staging endpoint if available.
+4. **Atomic swap:** Install new cert/key to staging path, `nginx -t`, then `reload` (not restart) to pick up files.
+5. **Verify:** `openssl s_client -connect host:443 -servername host` + smoke test critical paths.
+6. **Rollback plan:** Keep previous cert/key pair; on failure, restore files and `nginx -s reload` within minutes.
+7. **Audit:** Log rotation event (who, when, serial numbers, ticket ID) in change-management / SIEM.
+
+### What OCSP stapling buys you (production vs lab)
+
+OCSP stapling lets the server attach a fresh revocation status to the TLS handshake, so clients avoid extra latency and privacy leaks from contacting the CA OCSP responder directly. On a self-signed lab cert there is no public CA OCSP responder, so stapling is configured but has no effect — in production with Let's Encrypt or enterprise PKI it reduces handshake round-trips and improves privacy.
+
+---
+
+## Bonus: WAF Sidecar with OWASP CRS
+
+### Setup choice
+
+- **WAF used:** ModSecurity v3 (`owasp/modsecurity-crs:nginx-alpine`)
+- **OWASP CRS version:** 3.3.10 (CRS v3 ruleset in image)
+- **Paranoia level:** 1
+- **WAF port:** `9443` (8443 occupied by DefectDojo from Lab 10)
+
+### Attack payload sent
+
+`GET /rest/products/search?q=' OR 1=1--` (URL-encoded)
+
+### Before WAF (Nginx alone)
+
+```
+no-waf: HTTP 500
+```
+
+*(Request reaches Juice Shop — not blocked by Nginx; 500 is app error on malicious query)*
+
+### After WAF
+
+```
+with-waf: HTTP 403
+```
+
+### Audit log excerpt (the rule that fired)
+
+```
+ModSecurity: Access denied with code 403 (phase 2) ...
+[id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"]
+...
+"ruleId":"942100"
+"message":"SQL Injection Attack Detected via libinjection"
+"data":"Matched Data: s&1c found within ARGS:q: ' OR 1=1--"
+```
+
+Rule ID: **942100** — OWASP CRS rule name: **SQL Injection Attack Detected via libinjection**
+
+### Tradeoff analysis (3 sentences)
+
+A WAF blocks exploit-shaped HTTP at the edge — categories of attacks that SAST/DAST miss at deploy time and that Conftest cannot see in runtime HTTP traffic. It costs operational overhead: tuning paranoia levels, false positives, audit-log storage, and another moving part in the request path. Skip a WAF for low-risk internal APIs behind mTLS, or when latency/complexity outweighs threat (e.g. static CDN-only sites with no user input).


### PR DESCRIPTION
## Pull Request

## Goal

Harden the Nginx reverse proxy in front of Juice Shop with TLS 1.3 + security headers, rate limiting/timeouts/cipher hardening, and (bonus) a ModSecurity v3 + OWASP CRS WAF sidecar that blocks a SQLi payload Nginx alone passes through.

## Changes

- `labs/lab11/reverse-proxy/nginx.conf` — TLS 1.3-only config, 6 security headers (`always`), rate limiting (`limit_req`/`limit_conn`), fail-closed timeouts, `ssl_ecdh_curve X25519:secp384r1`, session hardening (`ssl_session_tickets off`); OCSP stapling directives documented but commented out for self-signed cert
- `labs/lab11/docker-compose.yml` — nginx + juice-shop stack (ports 80/443)
- `labs/lab11/waf/docker-compose.waf.yml` — ModSecurity v3 + OWASP CRS (`owasp/modsecurity-crs:nginx-alpine`, paranoia 1), reverse-proxying to hardened nginx backend on **:9443**
- `labs/lab11/waf/docker-compose.override.yml` — alternate compose merge for WAF stack
- `labs/lab11/.gitignore` — excludes `certs/`, `logs/`, `results/`
- `submissions/lab11.md` — full write-up with proof for all three tasks
- `submissions/lab11-setup-kali.sh`, `submissions/lab11-collect.sh` — setup + results collection helpers

## Testing

- `openssl s_client -connect localhost:443 -tls1_3` → `Protocol version: TLSv1.3`, `Ciphersuite: TLS_AES_256_GCM_SHA384`
- `curl -skI https://localhost` → all 6 security headers present (HSTS, X-CTO, X-FO, Referrer-Policy, Permissions-Policy, CSP-Report-Only)
- `curl -sI http://localhost` → `308 Permanent Redirect` to `https://localhost/`
- `client_header_timeout 10s` — connection torn down on slow/partial request to :443
- Rate limit on `/rest/user/login` (10r/m, burst=5) → **54× HTTP 429**, 6× 401 out of 60 concurrent POSTs
- **Bonus:** `curl` to `/rest/products/search?q=' OR 1=1--` → **HTTP 500** through Nginx alone (not blocked), **HTTP 403** through WAF on `https://localhost:9443`; docker logs confirm OWASP CRS rule **942100** (*SQL Injection Attack Detected via libinjection*) and aggregate rule **949110** (*Inbound Anomaly Score Exceeded*)

## Artifacts & Screenshots

- `submissions/lab11.md` — full submission with all proof blocks
- Local only (gitignored, not committed): `labs/lab11/results/tls13.txt`, `headers.txt`, `http-redirect.txt`, `timeout.txt`, `ratelimit.txt`, `cipher.txt`, `waf-baseline.txt`, `waf-blocked.txt`, `waf-audit.txt`

---

- [x] Title uses `feat(labN): <topic>` style
- [x] No secrets/large temp files committed (`certs/`, `logs/`, `results/` gitignored)
- [x] `submissions/lab11.md` present

- [x] Task 1 — TLS 1.3 + 6 security headers (with proof)
- [x] Task 2 — Rate limit + timeouts + cipher hardening + cert-rotation runbook
- [x] Bonus — ModSec WAF + OWASP CRS catching a payload Nginx-alone passes

**Branch:** `feature/lab11`

**Fork PR:** https://github.com/Nopef/DevSecOps-Intro/compare/main...feature/lab11?expand=1

**Course PR:** https://github.com/inno-devops-labs/DevSecOps-Intro/compare/main...Nopef:feature/lab11?expand=1
