### PR TITLE
feat(lab11): hardened nginx reverse proxy and waf

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Goal
+Describe in one sentence what this PR delivers.
+
+## Changes
+- Added/updated:
+- Added/updated:
+- Added/updated:
+
+## Testing
+List the commands you ran and the observed results.
+
+```bash
+# paste commands here
+```
+
+Observed output/results:
+- 
+- 
+- 
+
+## Artifacts & Screenshots
+- Submission file: `submissions/labN.md`
+- Other artifacts:
+- Screenshots:
+
+- [ ] Title is clear (`feat(labN): <topic>` style)
+- [ ] No secrets/large temp files committed
+- [ ] Submission file at `submissions/labN.md` exists

--- a/.github/workflows/lab1-smoke.yml
+++ b/.github/workflows/lab1-smoke.yml
@@ -1,0 +1,40 @@
+name: Lab 1 Smoke Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Pull Juice Shop image
+        run: docker pull bkimminich/juice-shop:v20.0.0
+
+      - name: Start Juice Shop
+        run: |
+          docker run -d \
+            --name juice-shop \
+            -p 3000:3000 \
+            bkimminich/juice-shop:v20.0.0
+
+      - name: Wait for application
+        run: |
+          for i in $(seq 1 30); do
+            curl --silent --fail http://localhost:3000/rest/admin/application-version >/dev/null && exit 0
+            sleep 2
+          done
+          exit 1
+
+      - name: Verify homepage returns HTTP 200
+        run: |
+          test "$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/)" = "200"
+
+      - name: Show HTTP status code
+        run: |
+          curl -is http://localhost:3000/ | head -n1

--- a/labs/lab11/reverse-proxy/nginx.conf
+++ b/labs/lab11/reverse-proxy/nginx.conf
@@ -29,6 +29,7 @@ http {
   # Rate limit zone for login
   # ~10 req/min per IP, burst of 5
   limit_req_zone $binary_remote_addr zone=login:10m rate=10r/m;
+  limit_conn_zone $binary_remote_addr zone=conn:10m;
   limit_req_status 429;
 
   map $http_upgrade $connection_upgrade { default upgrade; '' close; }
@@ -47,13 +48,11 @@ http {
   proxy_send_timeout 30s;
   proxy_connect_timeout 5s;
   proxy_hide_header X-Powered-By;
-  # Hide upstream headers to avoid duplicates and enforce policy at the proxy
   proxy_hide_header X-Frame-Options;
   proxy_hide_header X-Content-Type-Options;
   proxy_hide_header Referrer-Policy;
   proxy_hide_header Permissions-Policy;
-  proxy_hide_header Cross-Origin-Opener-Policy;
-  proxy_hide_header Cross-Origin-Resource-Policy;
+  proxy_hide_header Feature-Policy;
   proxy_hide_header Content-Security-Policy;
   proxy_hide_header Content-Security-Policy-Report-Only;
   proxy_hide_header Access-Control-Allow-Origin;
@@ -63,15 +62,6 @@ http {
     listen 80;
     listen [::]:80;
     server_name _;
-
-    # Core headers (also on redirects)
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
 
     return 308 https://$host$request_uri;
   }
@@ -85,11 +75,12 @@ http {
 
     ssl_certificate     /etc/nginx/certs/localhost.crt;
     ssl_certificate_key /etc/nginx/certs/localhost.key;
-    ssl_session_timeout 10m;
+    ssl_session_timeout 1d;
     ssl_session_cache   shared:SSL:10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:EECDH+AESGCM:EDH+AESGCM";
-    ssl_prefer_server_ciphers on;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.3;
+    ssl_ecdh_curve X25519:secp384r1;
+    ssl_prefer_server_ciphers off;
     ssl_stapling off;
     # If using a publicly-trusted certificate, you may enable OCSP stapling:
     # ssl_stapling on;
@@ -103,16 +94,15 @@ http {
     client_header_timeout 10s;
     keepalive_timeout 10s;
     send_timeout 10s;
+    limit_conn conn 50;
 
-    # Security headers (include HSTS here only)
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    # Security headers
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' https: data:; connect-src 'self' https:;" always;
 
     location = /rest/user/login {
       limit_req zone=login burst=5 nodelay;

--- a/labs/lab11/waf/docker-compose.override.yml
+++ b/labs/lab11/waf/docker-compose.override.yml
@@ -1,0 +1,23 @@
+services:
+  waf:
+    image: owasp/modsecurity-crs:4.25-nginx-lts
+    restart: unless-stopped
+    depends_on:
+      - juice
+    ports:
+      - "9080:8080"
+      - "9443:8443"
+    environment:
+      BACKEND: "http://juice:3000"
+      SERVER_NAME: "localhost"
+      PORT: "8080"
+      SSL_PORT: "8443"
+      PARANOIA: "1"
+      MODSEC_RULE_ENGINE: "On"
+      MODSEC_AUDIT_ENGINE: "On"
+      MODSEC_AUDIT_LOG: "/var/log/modsec/audit.log"
+      MODSEC_AUDIT_LOG_FORMAT: "Native"
+      MODSEC_AUDIT_LOG_PARTS: "ABIJDEFHZ"
+      MODSEC_AUDIT_LOG_TYPE: "Serial"
+    volumes:
+      - ./waf/logs:/var/log/modsec

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,149 @@
+# Lab 11 — BONUS — Submission
+
+## Task 1: TLS + Security Headers
+
+### nginx.conf (SSL + header sections only)
+```nginx
+  server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    return 308 https://$host$request_uri;
+  }
+
+  server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/certs/localhost.crt;
+    ssl_certificate_key /etc/nginx/certs/localhost.key;
+    ssl_session_timeout 1d;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.3;
+    ssl_ecdh_curve X25519:secp384r1;
+    ssl_prefer_server_ciphers off;
+    ssl_stapling off;
+
+    client_max_body_size 2m;
+    client_body_timeout 10s;
+    client_header_timeout 10s;
+    keepalive_timeout 10s;
+    send_timeout 10s;
+    limit_conn conn 50;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' https: data:; connect-src 'self' https:;" always;
+```
+
+### A. HTTPS redirect proof
+```text
+HTTP/1.1 308 Permanent Redirect
+Location: https://localhost/
+```
+
+### B. TLS 1.3 proof
+```text
+Connecting to 127.0.0.1
+Can't use SSL_get_servername
+depth=0 CN=juice.local
+verify error:num=18:self-signed certificate
+CONNECTION ESTABLISHED
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_256_GCM_SHA384
+Peer certificate: CN=juice.local
+```
+
+### C. Security headers proof (all 6 present)
+```text
+HTTP/2 200
+strict-transport-security: max-age=63072000; includeSubDomains; preload
+x-frame-options: DENY
+x-content-type-options: nosniff
+referrer-policy: strict-origin-when-cross-origin
+permissions-policy: camera=(), geolocation=(), microphone=()
+content-security-policy-report-only: default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' https: data:; connect-src 'self' https:;
+```
+
+### What each header defends against
+- HSTS: forces browsers to keep using HTTPS and prevents downgrade / SSL stripping after first trusted visit.
+- X-Content-Type-Options `nosniff`: stops browsers from MIME-sniffing content into executable types such as script.
+- X-Frame-Options `DENY`: blocks clickjacking by preventing the site from being framed.
+- Referrer-Policy: limits how much origin and path information is leaked to other sites via the `Referer` header.
+- Permissions-Policy: disables sensitive browser features such as camera, microphone, and geolocation unless explicitly allowed.
+- Content-Security-Policy: constrains what sources the browser may load active content from; using report-only here avoids breaking Juice Shop while still showing intended policy direction.
+
+## Task 2: Production Posture
+
+### Rate limit proof
+| HTTP code | Count out of 60 |
+|-----------|----------------:|
+| 200 | 0 |
+| 429 | 54 |
+| 5xx | 6 |
+
+### Timeout enforced
+```text
+Configured in nginx with:
+client_body_timeout 10s;
+client_header_timeout 10s;
+proxy_read_timeout 30s;
+proxy_connect_timeout 5s;
+```
+
+### Cipher hardening
+```text
+New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
+```
+
+### Cert rotation runbook (7 steps)
+1. **Detect expiry**: monitor certificate expiration in inventory/alerting and trigger renewal before the warning threshold.
+2. **Order new cert**: request a replacement certificate from the CA or ACME workflow for the same hostname set.
+3. **Validate**: verify SANs, chain, private key match, and staging deployment before production swap.
+4. **Atomic swap**: place the new cert/key beside the old pair and update the mounted files or symlink in one controlled step.
+5. **Verify**: run `openssl s_client` and `curl -I` checks immediately after reload to confirm the new cert, protocol, and headers are live.
+6. **Rollback plan**: keep the previous cert/key pair available so the proxy can be reloaded back to the last known-good state if validation fails.
+7. **Audit**: record the rotation date, operator, cert serial/fingerprint, validation evidence, and any incident notes.
+
+### What OCSP stapling buys you
+OCSP stapling lets the server attach revocation proof during the TLS handshake so clients do not each need to contact the CA directly, which improves privacy and reduces latency. It is useful in production with publicly trusted certificates, but it does not help in this lab because the certificate is self-signed and has no CA-operated OCSP responder to query.
+
+## Bonus: WAF Sidecar with OWASP CRS
+
+### Setup choice
+- WAF used: `ModSecurity v3 / OWASP CRS docker image`
+- OWASP CRS version: `4.25.1`
+- Paranoia level: `1`
+
+### Attack payload sent
+`GET /rest/products/search?q=' OR 1=1--` (URL-encoded)
+
+### Before WAF (Nginx alone)
+```text
+no-waf: HTTP 500
+```
+
+### After WAF
+```text
+with-waf: HTTP 403
+```
+
+### Audit log excerpt (the rule that fired)
+```text
+GET /rest/products/search?q=%27%20OR%201=1-- HTTP/2.0
+
+ModSecurity: Warning. detected SQLi using libinjection. [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf"] [line "46"] [id "942100"] [msg "SQL Injection Attack Detected via libinjection"] [data "Matched Data: s&1c found within ARGS:q: ' OR 1=1--"] [severity "2"] [ver "OWASP_CRS/4.25.1"] [tag "attack-sqli"] [tag "paranoia-level/1"] [uri "/rest/products/search"]
+ModSecurity: Access denied with code 403 (phase 2). Matched "Operator `Ge' with parameter `5' against variable `TX:BLOCKING_INBOUND_ANOMALY_SCORE' (Value: `5' ) [file "/etc/modsecurity.d/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] [line "222"] [id "949110"] [msg "Inbound Anomaly Score Exceeded (Total Score: 5)"] [ver "OWASP_CRS/4.25.1"] [uri "/rest/products/search"]
+```
+
+Rule ID: **942100** — OWASP CRS rule name: **SQL Injection Attack Detected via libinjection**
+
+### Tradeoff analysis
+The WAF adds a runtime enforcement layer that can block generic exploit payloads even if SAST, DAST, or config policy did not prevent the vulnerable request path from reaching the service. The cost is operational complexity: more moving parts, more tuning work, and false-positive risk as paranoia levels increase. I would avoid deploying a WAF in front of very latency-sensitive or tightly controlled internal services if the rule-tuning overhead outweighs the actual attack-surface reduction.


### PR DESCRIPTION
## Goal
Deliver the Lab 11 bonus submission with a hardened Nginx reverse proxy in front of Juice Shop and an OWASP CRS WAF layer that blocks a real SQL injection probe.

## Changes
- Added/updated: `labs/lab11/reverse-proxy/nginx.conf` with HTTPS redirect, TLS 1.3 only, required security headers, rate limiting, connection limits, and production-style timeout hardening
- Added/updated: `labs/lab11/waf/docker-compose.override.yml` to run an OWASP CRS WAF sidecar in front of Juice Shop on a separate HTTPS listener
- Added/updated: `submissions/lab11.md` with TLS/header evidence, rate-limit proof, certificate-rotation runbook, and WAF audit-log analysis

## Testing
List the commands you ran and the observed results.

```bash
openssl req -x509 -nodes -newkey rsa:4096 \
  -keyout labs/lab11/reverse-proxy/certs/localhost.key \
  -out labs/lab11/reverse-proxy/certs/localhost.crt \
  -subj "/CN=juice.local" \
  -days 3650

cd labs/lab11
docker compose up -d
docker compose ps
until curl -sk https://localhost/rest/admin/application-version > /dev/null; do sleep 2; done

curl -sI http://localhost
echo | openssl s_client -connect localhost:443 -tls1_3 -brief 2>&1 | head -8
curl -skI https://localhost

seq 1 60 | xargs -n1 -P 30 -I{} curl -sk -o /dev/null -w "%{http_code}\n" \
  https://localhost/rest/user/login 2>/dev/null | sort | uniq -c

echo | openssl s_client -connect localhost:443 -tls1_3 2>&1 | grep -E "Cipher|Server Temp Key"

docker compose -f docker-compose.yml -f waf/docker-compose.override.yml up -d
curl -sk -o /dev/null -w "no-waf: HTTP %{http_code}\n" \
  "https://localhost/rest/products/search?q=%27%20OR%201=1--"
curl -sk -o /dev/null -w "with-waf: HTTP %{http_code}\n" \
  "https://localhost:9443/rest/products/search?q=%27%20OR%201=1--"
docker compose -f docker-compose.yml -f waf/docker-compose.override.yml exec waf \
  sh -lc 'cat /var/log/modsec/audit.log | tail -50'
```

Observed output/results:
- HTTP redirected to HTTPS and `openssl s_client` confirmed `Protocol version: TLSv1.3`
- The hardened proxy response included HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and CSP-Report-Only headers
- Rate limiting produced `54` responses with `429` out of `60` login attempts, with the remainder returning `500`
- Without WAF the SQLi probe reached the application and returned `HTTP 500`, while through the WAF listener it was blocked with `HTTP 403`
- The WAF audit log showed OWASP CRS rule `942100` followed by blocking evaluation rule `949110`

## Artifacts & Screenshots
- Submission file: `submissions/lab11.md`
- Other artifacts: `labs/lab11/reverse-proxy/nginx.conf`, `labs/lab11/waf/docker-compose.override.yml`
- Screenshots: none

- [x] Title is clear (`feat(lab11): <topic>` style)
- [x] No secrets/large temp files committed
- [x] Submission file at `submissions/lab11.md` exists